### PR TITLE
fix: strip Expect header to prevent NotSupportedError in undici

### DIFF
--- a/.changeset/dry-buckets-cut.md
+++ b/.changeset/dry-buckets-cut.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": patch
+---
+
+Strip Expect header to prevent NotSupportedError in undici

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -280,6 +280,60 @@ describe("UndiciHttpHandler", () => {
     });
   });
 
+  describe("expect header", () => {
+    it("strips Expect header before sending to undici", async () => {
+      const mockDispatcher = {
+        request: vi.fn().mockResolvedValue({
+          statusCode: 200,
+          headers: {},
+          body: null,
+        }),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      await handler.handle(
+        createMockRequest({
+          method: "PUT",
+          headers: {
+            "content-type": "application/octet-stream",
+            Expect: "100-continue",
+          },
+        }),
+      );
+
+      const callArgs = (mockDispatcher.request as any).mock.calls[0][0];
+      expect(callArgs.headers).not.toHaveProperty("Expect");
+      expect(callArgs.headers).not.toHaveProperty("expect");
+    });
+
+    it("strips lowercase expect header", async () => {
+      const mockDispatcher = {
+        request: vi.fn().mockResolvedValue({
+          statusCode: 200,
+          headers: {},
+          body: null,
+        }),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      await handler.handle(
+        createMockRequest({
+          method: "PUT",
+          headers: {
+            "content-type": "application/octet-stream",
+            expect: "100-continue",
+          },
+        }),
+      );
+
+      const callArgs = (mockDispatcher.request as any).mock.calls[0][0];
+      expect(callArgs.headers).not.toHaveProperty("Expect");
+      expect(callArgs.headers).not.toHaveProperty("expect");
+    });
+  });
+
   describe("destroy", () => {
     it("destroys internal dispatcher", async () => {
       handler = new UndiciHttpHandler();

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -45,7 +45,9 @@ export interface UndiciHttpHandlerOptions {
  * An HTTP handler that uses undici instead of Node.js native http/https modules.
  * Drop-in replacement for `NodeHttpHandler` from `@smithy/node-http-handler`.
  */
-export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> {
+export class UndiciHttpHandler
+  implements HttpHandler<UndiciHttpHandlerOptions>
+{
   private config?: UndiciHttpHandlerOptions;
   private configProvider: Promise<UndiciHttpHandlerOptions>;
   private dispatcher?: Dispatcher;
@@ -167,6 +169,13 @@ export class UndiciHttpHandler implements HttpHandler<UndiciHttpHandlerOptions> 
     // undici natively supports string | Buffer | Uint8Array | Readable | AsyncIterable as body.
     // Pass through directly to avoid buffering streams into memory.
     const body = request.body ?? null;
+
+    // undici does not support the Expect header through its request() API.
+    // The AWS SDK adds "Expect: 100-continue" for large request bodies, but
+    // undici sends the body immediately without waiting for a 100 Continue
+    // response, so the header is unnecessary and must be removed.
+    delete request.headers["Expect"];
+    delete request.headers["expect"];
 
     // Build undici request options
     const effectiveTimeout = requestTimeout ?? config.requestTimeout ?? 0;


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/trivikr/trivikr-test-undici-http-handler/issues/3

*Description of changes:*

Strip Expect header to prevent NotSupportedError in undici

Verified that putObject works

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
