### PR TITLE
fix: treat errors with code 'UND_ERR_SOCKET' as RequestTimeout

### DIFF
--- a/.changeset/silver-sails-find.md
+++ b/.changeset/silver-sails-find.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": patch
+---
+
+Rethrow errors with code 'UND_ERR_SOCKET' as RequestTimeout

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -221,6 +221,20 @@ describe("UndiciHttpHandler", () => {
       ).rejects.toThrow("Request aborted");
     });
 
+    it("throws error with name AbortError if signal is already aborted", async () => {
+      handler = new UndiciHttpHandler();
+      const controller = new AbortController();
+      controller.abort();
+      try {
+        await handler.handle(createMockRequest(), {
+          abortSignal: controller.signal as any,
+        });
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("AbortError");
+      }
+    });
+
     it("throws AbortError when signal is aborted during request", async () => {
       handler = new UndiciHttpHandler();
       const controller = new AbortController();
@@ -230,6 +244,26 @@ describe("UndiciHttpHandler", () => {
           abortSignal: controller.signal as any,
         }),
       ).rejects.toThrow();
+    });
+
+    it("sets name to AbortError on UND_ERR_ABORTED and preserves original error", async () => {
+      const abortError = Object.assign(new Error("aborted"), {
+        code: "UND_ERR_ABORTED",
+      });
+      const mockDispatcher = {
+        request: vi.fn().mockRejectedValue(abortError),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      try {
+        await handler.handle(createMockRequest());
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("AbortError");
+        expect(err.code).toBe("UND_ERR_ABORTED");
+        expect(err).toBe(abortError);
+      }
     });
   });
 
@@ -248,6 +282,107 @@ describe("UndiciHttpHandler", () => {
           requestTimeout: 50,
         }),
       ).rejects.toThrow();
+    });
+
+    it("sets name to TimeoutError on UND_ERR_HEADERS_TIMEOUT and preserves original error", async () => {
+      const timeoutError = Object.assign(new Error("headers timed out"), {
+        code: "UND_ERR_HEADERS_TIMEOUT",
+      });
+      const mockDispatcher = {
+        request: vi.fn().mockRejectedValue(timeoutError),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      try {
+        await handler.handle(createMockRequest());
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("TimeoutError");
+        expect(err.code).toBe("UND_ERR_HEADERS_TIMEOUT");
+        expect(err).toBe(timeoutError);
+      }
+    });
+
+    it("sets name to TimeoutError on UND_ERR_BODY_TIMEOUT and preserves original error", async () => {
+      const timeoutError = Object.assign(new Error("body timed out"), {
+        code: "UND_ERR_BODY_TIMEOUT",
+      });
+      const mockDispatcher = {
+        request: vi.fn().mockRejectedValue(timeoutError),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      try {
+        await handler.handle(createMockRequest());
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("TimeoutError");
+        expect(err.code).toBe("UND_ERR_BODY_TIMEOUT");
+        expect(err).toBe(timeoutError);
+      }
+    });
+
+    it("sets name to TimeoutError on UND_ERR_CONNECT_TIMEOUT and preserves original error", async () => {
+      const timeoutError = Object.assign(new Error("connect timed out"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      });
+      const mockDispatcher = {
+        request: vi.fn().mockRejectedValue(timeoutError),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      try {
+        await handler.handle(createMockRequest());
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("TimeoutError");
+        expect(err.code).toBe("UND_ERR_CONNECT_TIMEOUT");
+        expect(err).toBe(timeoutError);
+      }
+    });
+  });
+
+  describe("socket errors", () => {
+    it("sets name to RequestTimeout on UND_ERR_SOCKET and preserves original error", async () => {
+      const socketError = Object.assign(new Error("socket error"), {
+        code: "UND_ERR_SOCKET",
+      });
+      const mockDispatcher = {
+        request: vi.fn().mockRejectedValue(socketError),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      try {
+        await handler.handle(createMockRequest());
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err.name).toBe("RequestTimeout");
+        expect(err.code).toBe("UND_ERR_SOCKET");
+        expect(err).toBe(socketError);
+      }
+    });
+  });
+
+  describe("unknown errors", () => {
+    it("rethrows unknown errors unmodified", async () => {
+      const unknownError = new Error("something unexpected");
+      const mockDispatcher = {
+        request: vi.fn().mockRejectedValue(unknownError),
+        destroy: vi.fn(),
+      } as unknown as Dispatcher;
+
+      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+      try {
+        await handler.handle(createMockRequest());
+        expect.unreachable("should have thrown");
+      } catch (err: any) {
+        expect(err).toBe(unknownError);
+        expect(err.message).toBe("something unexpected");
+      }
     });
   });
 

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -140,7 +140,9 @@ export class UndiciHttpHandler
     const dispatcher = this.getOrCreateDispatcher(config);
 
     if (abortSignal?.aborted) {
-      throw buildAbortError();
+      throw Object.assign(new Error("Request aborted"), {
+        name: "AbortError",
+      });
     }
 
     // Build the full URL
@@ -216,17 +218,20 @@ export class UndiciHttpHandler
 
       return { response: httpResponse };
     } catch (err: any) {
-      if (err?.name === "AbortError" || err?.code === "UND_ERR_ABORTED") {
-        throw buildAbortError();
+      if (err?.code === "UND_ERR_ABORTED") {
+        throw Object.assign(err, { name: "AbortError" });
       }
+
       if (
-        err?.code === "UND_ERR_HEADERS_TIMEOUT" ||
         err?.code === "UND_ERR_BODY_TIMEOUT" ||
-        err?.code === "UND_ERR_CONNECT_TIMEOUT"
+        err?.code === "UND_ERR_CONNECT_TIMEOUT" ||
+        err?.code === "UND_ERR_HEADERS_TIMEOUT"
       ) {
-        throw Object.assign(new Error(`Request timeout: ${err.message}`), {
-          name: "TimeoutError",
-        });
+        throw Object.assign(err, { name: "TimeoutError" });
+      }
+
+      if (err?.code === "UND_ERR_SOCKET") {
+        throw Object.assign(err, { name: "RequestTimeout" });
       }
       throw err;
     }
@@ -246,10 +251,4 @@ export class UndiciHttpHandler
   public httpHandlerConfigs(): UndiciHttpHandlerOptions {
     return this.config ?? {};
   }
-}
-
-function buildAbortError(): Error {
-  return Object.assign(new Error("Request aborted"), {
-    name: "AbortError",
-  });
 }


### PR DESCRIPTION
*Issue #, if available:*

Refs: https://github.com/trivikr/trivikr-test-undici-http-handler/issues/4

*Description of changes:*

Rethrows errors with code 'UND_ERR_SOCKET' as RequestTimeout
