### PR TITLE
test: add benchmarks comparing with NodeHttpHandler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,5 @@ jobs:
         run: yarn build
       - name: test
         run: yarn test
+      - name: benchmark
+        run: yarn benchmark

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  ci:
+  test:
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -27,5 +27,25 @@ jobs:
         run: yarn build
       - name: test
         run: yarn test
+      - name: benchmark
+        run: yarn benchmark
+
+  benchmark:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: corepack
+        run: npm i -g corepack
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: "yarn"
+      - name: install
+        run: yarn
+      - name: build
+        run: yarn build
       - name: benchmark
         run: yarn benchmark

--- a/benchmarks/http-handlers.mjs
+++ b/benchmarks/http-handlers.mjs
@@ -75,20 +75,6 @@ await drain((await undiciHandler.handle(makeRequest())).response);
 
 boxplot(() => {
   summary(() => {
-    bench("NodeHttpHandler  – single GET", async () => {
-      const { response } = await nodeHandler.handle(makeRequest());
-      await drain(response);
-    });
-
-    bench("UndiciHttpHandler – single GET", async () => {
-      const { response } = await undiciHandler.handle(makeRequest());
-      await drain(response);
-    });
-  });
-});
-
-boxplot(() => {
-  summary(() => {
     bench("NodeHttpHandler  – 10 sequential GETs", async () => {
       for (let i = 0; i < 10; i++) {
         const { response } = await nodeHandler.handle(makeRequest());

--- a/benchmarks/http-handlers.mjs
+++ b/benchmarks/http-handlers.mjs
@@ -1,0 +1,136 @@
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { HttpRequest } from "@smithy/protocol-http";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { UndiciHttpHandler } from "../dist/cjs/index.js";
+import { run, bench, boxplot, summary } from "mitata";
+
+// ---------------------------------------------------------------------------
+// 1. Spin up a local HTTP server
+// ---------------------------------------------------------------------------
+
+const RESPONSE_BODY = JSON.stringify({ ok: true, ts: Date.now() });
+
+const server = createServer((_req, res) => {
+  res.writeHead(200, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(RESPONSE_BODY),
+  });
+  res.end(RESPONSE_BODY);
+});
+
+server.listen(0, "127.0.0.1");
+await once(server, "listening");
+const { port } = server.address();
+
+// ---------------------------------------------------------------------------
+// 2. Helper to build a Smithy HttpRequest targeting the local server
+// ---------------------------------------------------------------------------
+
+function makeRequest(overrides = {}) {
+  return Object.assign(
+    new HttpRequest({
+      protocol: "http:",
+      hostname: "127.0.0.1",
+      port,
+      method: "GET",
+      path: "/",
+      headers: {},
+    }),
+    overrides,
+  );
+}
+
+// Drain the response body so the connection can be reused.
+async function drain(response) {
+  if (response.body) {
+    // response.body is a Readable / async iterable from both handlers
+    for await (const _ of response.body) {
+      // discard
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Create handler instances
+// ---------------------------------------------------------------------------
+
+const nodeHandler = new NodeHttpHandler({
+  connectionTimeout: 3000,
+  requestTimeout: 3000,
+});
+
+const undiciHandler = new UndiciHttpHandler({
+  connectionTimeout: 3000,
+  requestTimeout: 3000,
+});
+
+// Warm up both handlers so first-request setup cost is excluded.
+await drain((await nodeHandler.handle(makeRequest())).response);
+await drain((await undiciHandler.handle(makeRequest())).response);
+
+// ---------------------------------------------------------------------------
+// 4. Benchmarks
+// ---------------------------------------------------------------------------
+
+boxplot(() => {
+  summary(() => {
+    bench("NodeHttpHandler  – single GET", async () => {
+      const { response } = await nodeHandler.handle(makeRequest());
+      await drain(response);
+    });
+
+    bench("UndiciHttpHandler – single GET", async () => {
+      const { response } = await undiciHandler.handle(makeRequest());
+      await drain(response);
+    });
+  });
+});
+
+boxplot(() => {
+  summary(() => {
+    bench("NodeHttpHandler  – 10 sequential GETs", async () => {
+      for (let i = 0; i < 10; i++) {
+        const { response } = await nodeHandler.handle(makeRequest());
+        await drain(response);
+      }
+    });
+
+    bench("UndiciHttpHandler – 10 sequential GETs", async () => {
+      for (let i = 0; i < 10; i++) {
+        const { response } = await undiciHandler.handle(makeRequest());
+        await drain(response);
+      }
+    });
+  });
+});
+
+boxplot(() => {
+  summary(() => {
+    bench("NodeHttpHandler  – 50 concurrent GETs", async () => {
+      const tasks = Array.from({ length: 50 }, async () => {
+        const { response } = await nodeHandler.handle(makeRequest());
+        await drain(response);
+      });
+      await Promise.all(tasks);
+    });
+
+    bench("UndiciHttpHandler – 50 concurrent GETs", async () => {
+      const tasks = Array.from({ length: 50 }, async () => {
+        const { response } = await undiciHandler.handle(makeRequest());
+        await drain(response);
+      });
+      await Promise.all(tasks);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Run and clean up
+// ---------------------------------------------------------------------------
+
+await run();
+
+nodeHandler.destroy();
+undiciHandler.destroy();
+server.close();

--- a/benchmarks/http-handlers.mjs
+++ b/benchmarks/http-handlers.mjs
@@ -115,8 +115,10 @@ boxplot(() => {
 // 5. Run and clean up
 // ---------------------------------------------------------------------------
 
-await run();
-
-nodeHandler.destroy();
-undiciHandler.destroy();
-server.close();
+try {
+  await run();
+} finally {
+  nodeHandler.destroy();
+  undiciHandler.destroy();
+  server.close();
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
+    "benchmark": "node --expose-gc benchmarks/http-handlers.mjs",
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
@@ -35,8 +36,10 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
+    "@smithy/node-http-handler": "^4.6.1",
     "@types/node": "^20.0.0",
     "concurrently": "^9.0.0",
+    "mitata": "^1.0.34",
     "typescript": "~5.7.0",
     "vitest": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "benchmark": "node --expose-gc benchmarks/http-handlers.mjs",
+    "benchmark": "yarn build && node --expose-gc benchmarks/http-handlers.mjs",
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./dist/es/index.js",
   "types": "./dist/types/index.d.ts",
   "scripts": {
-    "benchmark": "yarn build && node --expose-gc benchmarks/http-handlers.mjs",
+    "benchmark": "node --expose-gc benchmarks/http-handlers.mjs",
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,7 +492,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/protocol-http@npm:^5.0.0":
+"@smithy/node-http-handler@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@smithy/node-http-handler@npm:4.6.1"
+  dependencies:
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/querystring-builder": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6c07fbfd8326cd5369283bd19c1af923ee49b7dcf42fdd199bb7132e4c25eaa6db8573e3b669fb60be0d8f9757a3f2482cd0cf6d6631494255f08239d3036ed2
+  languageName: node
+  linkType: hard
+
+"@smithy/protocol-http@npm:^5.0.0, @smithy/protocol-http@npm:^5.3.14":
   version: 5.3.14
   resolution: "@smithy/protocol-http@npm:5.3.14"
   dependencies:
@@ -502,7 +514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/querystring-builder@npm:^4.0.0":
+"@smithy/querystring-builder@npm:^4.0.0, @smithy/querystring-builder@npm:^4.2.14":
   version: 4.2.14
   resolution: "@smithy/querystring-builder@npm:4.2.14"
   dependencies:
@@ -543,11 +555,13 @@ __metadata:
   resolution: "@trivikr-test/undici-http-handler@workspace:."
   dependencies:
     "@changesets/cli": "npm:^2.31.0"
+    "@smithy/node-http-handler": "npm:^4.6.1"
     "@smithy/protocol-http": "npm:^5.0.0"
     "@smithy/querystring-builder": "npm:^4.0.0"
     "@smithy/types": "npm:^4.0.0"
     "@types/node": "npm:^20.0.0"
     concurrently: "npm:^9.0.0"
+    mitata: "npm:^1.0.34"
     tslib: "npm:^2.6.2"
     typescript: "npm:~5.7.0"
     undici: "npm:^7.0.0"
@@ -1391,6 +1405,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.1.2"
   checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
+  languageName: node
+  linkType: hard
+
+"mitata@npm:^1.0.34":
+  version: 1.0.34
+  resolution: "mitata@npm:1.0.34"
+  checksum: 10c0/a78a0dd18203e47f444915e64e900e9686d5b6c53c461105f79a6b4795983a2f1fa573ce6fea697ebb29c31ff31b2e7e4f0ce072e0611e0313ebef274a0a5811
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Runs three comparisons:
* 10 sequential requests: Undici is 6% faster
* 50 concurrent requests: Undici is 10% faster

```console
$ yarn benchmark

benchmark                             avg (min … max) p75 / p99    (min … top 1%)
----------------------------------------------------- -------------------------------
NodeHttpHandler  – 10 sequential GETs    1.08 ms/iter   1.08 ms  █▂                  
                                (912.58 µs … 3.31 ms)   2.18 ms  ██                  
                              ( 16.45 kb …   4.85 mb) 340.13 kb ▃██▇▄▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁

UndiciHttpHandler – 10 sequential GETs   1.01 ms/iter   1.01 ms   ▇█                 
                                (897.67 µs … 2.33 ms)   1.49 ms  ▂██▄                
                              (  2.25 kb …   5.28 mb) 278.46 kb ▃████▅▄▂▃▁▁▁▁▁▁▂▁▁▁▁▁

                                       ┌                                            ┐
                                        ╷ ┌──┬                                      ╷
 NodeHttpHandler  – 10 sequential GETs  ├─┤  │──────────────────────────────────────┤
                                        ╵ └──┴                                      ╵
                                       ╷ ┌─┬                ╷
UndiciHttpHandler – 10 sequential GETs ├─┤ │────────────────┤
                                       ╵ └─┴                ╵
                                       └                                            ┘
                                       897.67 µs           1.54 ms            2.18 ms

summary
  UndiciHttpHandler – 10 sequential GETs
   1.06x faster than NodeHttpHandler  – 10 sequential GETs

----------------------------------------------------- -------------------------------
NodeHttpHandler  – 50 concurrent GETs    3.71 ms/iter   3.86 ms     ▂▂ ▇▃█           
                                  (3.20 ms … 4.95 ms)   4.53 ms  ▅█▆██▆████ ▄        
                              (280.92 kb …   3.06 mb)   1.31 mb █████████████▆█▆▁▂▇▃▃

UndiciHttpHandler – 50 concurrent GETs   3.37 ms/iter   3.59 ms    █                 
                                  (2.91 ms … 4.62 ms)   4.08 ms  ▆██▅▆ ▇▅██▂▅▂       
                              (  1.91 kb …   2.69 mb)   1.06 mb ▅█████▆███████▆█▆▆▄▂▃

                                       ┌                                            ┐
                                               ╷      ┌──────┬───┐                  ╷
 NodeHttpHandler  – 50 concurrent GETs         ├──────┤      │   ├──────────────────┤
                                               ╵      └──────┴───┘                  ╵
                                       ╷    ┌───────┬─────┐             ╷
UndiciHttpHandler – 50 concurrent GETs ├────┤       │     ├─────────────┤
                                       ╵    └───────┴─────┘             ╵
                                       └                                            ┘
                                       2.91 ms            3.72 ms             4.53 ms

summary
  UndiciHttpHandler – 50 concurrent GETs
   1.1x faster than NodeHttpHandler  – 50 concurrent GETs
```