### PR TITLE
benchmarks: add undici pipelining comparison

### DIFF
--- a/benchmarks/http-handlers.mjs
+++ b/benchmarks/http-handlers.mjs
@@ -70,9 +70,22 @@ const undiciDispatcher = new Agent({
 });
 const undiciHandler = new UndiciHttpHandler({ dispatcher: undiciDispatcher });
 
+const undiciPipeliningDispatcher = new Agent({
+  pipelining: 10,
+  bodyTimeout: 3000,
+  headersTimeout: 3000,
+  connect: {
+    timeout: 3000,
+  },
+});
+const undiciPipeliningHandler = new UndiciHttpHandler({
+  dispatcher: undiciPipeliningDispatcher,
+});
+
 // Warm up both handlers so first-request setup cost is excluded.
 await drain((await nodeHandler.handle(makeRequest())).response);
 await drain((await undiciHandler.handle(makeRequest())).response);
+await drain((await undiciPipeliningHandler.handle(makeRequest())).response);
 
 // ---------------------------------------------------------------------------
 // 4. Benchmarks
@@ -90,6 +103,14 @@ boxplot(() => {
     bench("UndiciHttpHandler – 10 sequential GETs", async () => {
       for (let i = 0; i < 10; i++) {
         const { response } = await undiciHandler.handle(makeRequest());
+        await drain(response);
+      }
+    });
+
+    bench("UndiciHttpHandler pipelining=10 – 10 sequential GETs", async () => {
+      for (let i = 0; i < 10; i++) {
+        const { response } =
+          await undiciPipeliningHandler.handle(makeRequest());
         await drain(response);
       }
     });
@@ -113,6 +134,15 @@ boxplot(() => {
       });
       await Promise.all(tasks);
     });
+
+    bench("UndiciHttpHandler pipelining=10 – 50 concurrent GETs", async () => {
+      const tasks = Array.from({ length: 50 }, async () => {
+        const { response } =
+          await undiciPipeliningHandler.handle(makeRequest());
+        await drain(response);
+      });
+      await Promise.all(tasks);
+    });
   });
 });
 
@@ -125,6 +155,8 @@ try {
 } finally {
   nodeHandler.destroy();
   undiciHandler.destroy();
+  undiciPipeliningHandler.destroy();
   undiciDispatcher.destroy();
+  undiciPipeliningDispatcher.destroy();
   server.close();
 }


### PR DESCRIPTION
Pipelining is not very beneficial

```console
clk: ~3.11 GHz
cpu: Apple M1 Pro
runtime: node 20.20.0 (arm64-darwin)

benchmark                                           avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------------------------------- -------------------------------
NodeHttpHandler  – 10 sequential GETs                695.20 µs/iter 687.38 µs    ██                
                                              (446.71 µs … 2.02 ms)   1.49 ms    ██                
                                            (  6.10 kb …   1.95 mb) 293.21 kb ▄▄▂██▅▄▄▂▂▂▂▂▁▁▂▂▁▁▁▁

UndiciHttpHandler – 10 sequential GETs               589.50 µs/iter 573.96 µs     █                
                                              (368.75 µs … 3.31 ms)   1.20 ms     █▃               
                                            (  1.00 kb …   1.88 mb) 228.57 kb ▂▂▁▅██▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁

UndiciHttpHandler pipelining=10 – 10 sequential GETs 542.24 µs/iter 551.79 µs    █▆                
                                            (469.67 µs … 943.25 µs) 814.42 µs   ▅██▅               
                                            (  2.03 kb … 920.97 kb) 195.55 kb ▁▅█████▄▂▂▂▁▁▁▁▁▁▁▁▁▁

                                                     ┌                                            ┐
                                                        ╷      ┌──┬                               ╷
               NodeHttpHandler  – 10 sequential GETs    ├──────┤  │───────────────────────────────┤
                                                        ╵      └──┴                               ╵
                                                     ╷     ┌──┬                       ╷
              UndiciHttpHandler – 10 sequential GETs ├─────┤  │───────────────────────┤
                                                     ╵     └──┴                       ╵
                                                         ╷ ┌┬          ╷
UndiciHttpHandler pipelining=10 – 10 sequential GETs     ├─┤│──────────┤
                                                         ╵ └┴          ╵
                                                     └                                            ┘
                                                     368.75 µs          930.29 µs           1.49 ms

summary
  UndiciHttpHandler pipelining=10 – 10 sequential GETs
   1.09x faster than UndiciHttpHandler – 10 sequential GETs
   1.28x faster than NodeHttpHandler  – 10 sequential GETs

------------------------------------------------------------------- -------------------------------
NodeHttpHandler  – 50 concurrent GETs                  2.17 ms/iter   2.25 ms      ▅█              
                                                (1.78 ms … 2.93 ms)   2.77 ms      ██▇▃▄           
                                            (318.95 kb …   3.60 mb)   1.20 mb ▃▄▃▄▆█████▇▅▄▄▃▄▄▂▁▃▁

UndiciHttpHandler – 50 concurrent GETs                 1.60 ms/iter   1.72 ms  █                   
                                                (1.43 ms … 2.24 ms)   2.13 ms  █▇                  
                                            (181.23 kb …   1.77 mb) 932.04 kb ▃███▅▄▄▃▂▄▄▄▃▃▂▂▂▂▂▁▁

UndiciHttpHandler pipelining=10 – 50 concurrent GETs   1.75 ms/iter   1.81 ms █▂ ▄                 
                                                (1.47 ms … 8.61 ms)   3.38 ms ██▆█▄                
                                            ( 96.41 kb …   1.43 mb) 925.26 kb █████▄▄▂▃▂▁▁▁▁▁▁▁▁▁▁▁

                                                     ┌                                            ┐
                                                             ╷     ┌──┬─┐           ╷
               NodeHttpHandler  – 50 concurrent GETs         ├─────┤  │ ├───────────┤
                                                             ╵     └──┴─┘           ╵
                                                     ╷┌──┬──┐        ╷
              UndiciHttpHandler – 50 concurrent GETs ├┤  │  ├────────┤
                                                     ╵└──┴──┘        ╵
                                                      ╷┌────┬─┐                                   ╷
UndiciHttpHandler pipelining=10 – 50 concurrent GETs  ├┤    │ ├───────────────────────────────────┤
                                                      ╵└────┴─┘                                   ╵
                                                     └                                            ┘
                                                     1.43 ms            2.40 ms             3.38 ms

summary
  UndiciHttpHandler – 50 concurrent GETs
   1.09x faster than UndiciHttpHandler pipelining=10 – 50 concurrent GETs
   1.35x faster than NodeHttpHandler  – 50 concurrent GET
```