### PR TITLE
benchmarks: add S3 GetObject benchmark

### DIFF
--- a/benchmarks/s3-get-object.mjs
+++ b/benchmarks/s3-get-object.mjs
@@ -45,8 +45,10 @@ const s3WithUndici = new S3Client({ requestHandler: undiciHandler });
 async function consumeBody(response) {
   const body = response.Body;
   if (body) {
-    // transformToByteArray reads the entire stream
-    await body.transformToByteArray();
+    // Discard the stream without buffering into memory
+    for await (const _ of body) {
+      // no-op: just drain the stream
+    }
   }
 }
 

--- a/benchmarks/s3-get-object.mjs
+++ b/benchmarks/s3-get-object.mjs
@@ -1,24 +1,42 @@
-import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { S3 } from "@aws-sdk/client-s3";
 import { NodeHttpHandler } from "@smithy/node-http-handler";
 import { UndiciHttpHandler } from "../dist/cjs/index.js";
 import { run, bench, boxplot, summary } from "mitata";
 import { Agent } from "undici";
+import { randomBytes } from "node:crypto";
 
 // ---------------------------------------------------------------------------
 // 1. Configuration from environment variables
 // ---------------------------------------------------------------------------
 
 const Bucket = process.env.TEST_BUCKET;
-const Key = process.env.TEST_KEY;
 
-if (!Bucket || !Key) {
-  console.error("ERROR: TEST_BUCKET and TEST_KEY environment variables must be set.");
-  console.error("Usage: TEST_BUCKET=my-bucket TEST_KEY=my-key node benchmarks/s3-get-object.mjs");
+if (!Bucket) {
+  console.error("ERROR: TEST_BUCKET environment variable must be set.");
+  console.error("Usage: TEST_BUCKET=my-bucket node benchmarks/s3-get-object.mjs");
   process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
-// 2. Create S3 clients with each HTTP handler
+// 2. Define test object sizes
+// ---------------------------------------------------------------------------
+
+const TEST_OBJECTS = [
+  { name: "test-object-16KB", size: 16 * 1024 },
+  { name: "test-object-32KB", size: 32 * 1024 },
+  { name: "test-object-64KB", size: 64 * 1024 },
+  { name: "test-object-128KB", size: 128 * 1024 },
+  { name: "test-object-256KB", size: 256 * 1024 },
+  { name: "test-object-512KB", size: 512 * 1024 },
+  { name: "test-object-1MB", size: 1 * 1024 * 1024 },
+  { name: "test-object-2MB", size: 2 * 1024 * 1024 },
+  { name: "test-object-4MB", size: 4 * 1024 * 1024 },
+  { name: "test-object-8MB", size: 8 * 1024 * 1024 },
+  { name: "test-object-16MB", size: 16 * 1024 * 1024 },
+];
+
+// ---------------------------------------------------------------------------
+// 3. Create S3 clients with each HTTP handler
 // ---------------------------------------------------------------------------
 
 const nodeHandler = new NodeHttpHandler({
@@ -35,17 +53,16 @@ const undiciDispatcher = new Agent({
 });
 const undiciHandler = new UndiciHttpHandler({ dispatcher: undiciDispatcher });
 
-const s3WithNode = new S3Client({ requestHandler: nodeHandler });
-const s3WithUndici = new S3Client({ requestHandler: undiciHandler });
+const s3WithNode = new S3({ requestHandler: nodeHandler });
+const s3WithUndici = new S3({ requestHandler: undiciHandler });
 
 // ---------------------------------------------------------------------------
-// 3. Helper to consume the response body
+// 4. Helper to consume the response body
 // ---------------------------------------------------------------------------
 
 async function consumeBody(response) {
   const body = response.Body;
   if (body) {
-    // Discard the stream without buffering into memory
     for await (const _ of body) {
       // no-op: just drain the stream
     }
@@ -53,49 +70,65 @@ async function consumeBody(response) {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Warm up both clients
+// 5. Upload test objects
 // ---------------------------------------------------------------------------
 
-console.log(`Benchmarking S3 GetObject: Bucket=${Bucket}, Key=${Key}\n`);
+console.log(`Uploading ${TEST_OBJECTS.length} test objects to Bucket=${Bucket}...\n`);
 
-await consumeBody(await s3WithNode.send(new GetObjectCommand({ Bucket, Key })));
-await consumeBody(await s3WithUndici.send(new GetObjectCommand({ Bucket, Key })));
+for (const obj of TEST_OBJECTS) {
+  const data = randomBytes(obj.size);
+  await s3WithNode.putObject({ Bucket, Key: obj.name, Body: data });
+  console.log(`  Uploaded ${obj.name} (${obj.size >= 1024 * 1024 ? `${obj.size / (1024 * 1024)}MB` : `${obj.size / 1024}KB`})`);
+}
+
+console.log("\nAll test objects uploaded. Starting benchmarks...\n");
 
 // ---------------------------------------------------------------------------
-// 5. Benchmarks
+// 6. Warm up both clients
+// ---------------------------------------------------------------------------
+
+await consumeBody(await s3WithNode.getObject({ Bucket, Key: TEST_OBJECTS[0].name }));
+await consumeBody(await s3WithUndici.getObject({ Bucket, Key: TEST_OBJECTS[0].name }));
+
+// ---------------------------------------------------------------------------
+// 7. Benchmarks – Serial downloads (all sizes)
 // ---------------------------------------------------------------------------
 
 boxplot(() => {
   summary(() => {
-    bench("NodeHttpHandler  – 10 sequential S3 GetObject", async () => {
-      for (let i = 0; i < 10; i++) {
-        const response = await s3WithNode.send(new GetObjectCommand({ Bucket, Key }));
+    bench("NodeHttpHandler  – serial GetObject (all sizes)", async () => {
+      for (const obj of TEST_OBJECTS) {
+        const response = await s3WithNode.getObject({ Bucket, Key: obj.name });
         await consumeBody(response);
       }
     });
 
-    bench("UndiciHttpHandler – 10 sequential S3 GetObject", async () => {
-      for (let i = 0; i < 10; i++) {
-        const response = await s3WithUndici.send(new GetObjectCommand({ Bucket, Key }));
+    bench("UndiciHttpHandler – serial GetObject (all sizes)", async () => {
+      for (const obj of TEST_OBJECTS) {
+        const response = await s3WithUndici.getObject({ Bucket, Key: obj.name });
         await consumeBody(response);
       }
     });
   });
 });
 
+// ---------------------------------------------------------------------------
+// 8. Benchmarks – Concurrent downloads (all sizes)
+// ---------------------------------------------------------------------------
+
 boxplot(() => {
   summary(() => {
-    bench("NodeHttpHandler  – 50 concurrent S3 GetObject", async () => {
-      const tasks = Array.from({ length: 50 }, async () => {
-        const response = await s3WithNode.send(new GetObjectCommand({ Bucket, Key }));
+    bench("NodeHttpHandler  – concurrent GetObject (all sizes)", async () => {
+      const tasks = TEST_OBJECTS.map(async (obj) => {
+        const response = await s3WithNode.getObject({ Bucket, Key: obj.name });
         await consumeBody(response);
       });
       await Promise.all(tasks);
     });
 
-    bench("UndiciHttpHandler – 50 concurrent S3 GetObject", async () => {
-      const tasks = Array.from({ length: 50 }, async () => {
-        const response = await s3WithUndici.send(new GetObjectCommand({ Bucket, Key }));
+    bench("UndiciHttpHandler – concurrent GetObject (all sizes)", async () => {
+      const tasks = TEST_OBJECTS.map(async (obj) => {
+        const response = await s3WithUndici.getObject({ Bucket, Key: obj.name });
         await consumeBody(response);
       });
       await Promise.all(tasks);
@@ -104,12 +137,18 @@ boxplot(() => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Run and clean up
+// 9. Run, clean up test objects, and destroy clients
 // ---------------------------------------------------------------------------
 
 try {
   await run();
 } finally {
+  console.log("\nCleaning up test objects...");
+  for (const obj of TEST_OBJECTS) {
+    await s3WithNode.deleteObject({ Bucket, Key: obj.name }).catch(() => {});
+  }
+  console.log("Cleanup complete.");
+
   nodeHandler.destroy();
   undiciHandler.destroy();
   undiciDispatcher.destroy();

--- a/benchmarks/s3-get-object.mjs
+++ b/benchmarks/s3-get-object.mjs
@@ -1,0 +1,116 @@
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { UndiciHttpHandler } from "../dist/cjs/index.js";
+import { run, bench, boxplot, summary } from "mitata";
+import { Agent } from "undici";
+
+// ---------------------------------------------------------------------------
+// 1. Configuration from environment variables
+// ---------------------------------------------------------------------------
+
+const Bucket = process.env.TEST_BUCKET;
+const Key = process.env.TEST_KEY;
+
+if (!Bucket || !Key) {
+  console.error("ERROR: TEST_BUCKET and TEST_KEY environment variables must be set.");
+  console.error("Usage: TEST_BUCKET=my-bucket TEST_KEY=my-key node benchmarks/s3-get-object.mjs");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Create S3 clients with each HTTP handler
+// ---------------------------------------------------------------------------
+
+const nodeHandler = new NodeHttpHandler({
+  connectionTimeout: 3000,
+  requestTimeout: 30000,
+});
+
+const undiciDispatcher = new Agent({
+  bodyTimeout: 30000,
+  headersTimeout: 30000,
+  connect: {
+    timeout: 3000,
+  },
+});
+const undiciHandler = new UndiciHttpHandler({ dispatcher: undiciDispatcher });
+
+const s3WithNode = new S3Client({ requestHandler: nodeHandler });
+const s3WithUndici = new S3Client({ requestHandler: undiciHandler });
+
+// ---------------------------------------------------------------------------
+// 3. Helper to consume the response body
+// ---------------------------------------------------------------------------
+
+async function consumeBody(response) {
+  const body = response.Body;
+  if (body) {
+    // transformToByteArray reads the entire stream
+    await body.transformToByteArray();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Warm up both clients
+// ---------------------------------------------------------------------------
+
+console.log(`Benchmarking S3 GetObject: Bucket=${Bucket}, Key=${Key}\n`);
+
+await consumeBody(await s3WithNode.send(new GetObjectCommand({ Bucket, Key })));
+await consumeBody(await s3WithUndici.send(new GetObjectCommand({ Bucket, Key })));
+
+// ---------------------------------------------------------------------------
+// 5. Benchmarks
+// ---------------------------------------------------------------------------
+
+boxplot(() => {
+  summary(() => {
+    bench("NodeHttpHandler  – 10 sequential S3 GetObject", async () => {
+      for (let i = 0; i < 10; i++) {
+        const response = await s3WithNode.send(new GetObjectCommand({ Bucket, Key }));
+        await consumeBody(response);
+      }
+    });
+
+    bench("UndiciHttpHandler – 10 sequential S3 GetObject", async () => {
+      for (let i = 0; i < 10; i++) {
+        const response = await s3WithUndici.send(new GetObjectCommand({ Bucket, Key }));
+        await consumeBody(response);
+      }
+    });
+  });
+});
+
+boxplot(() => {
+  summary(() => {
+    bench("NodeHttpHandler  – 50 concurrent S3 GetObject", async () => {
+      const tasks = Array.from({ length: 50 }, async () => {
+        const response = await s3WithNode.send(new GetObjectCommand({ Bucket, Key }));
+        await consumeBody(response);
+      });
+      await Promise.all(tasks);
+    });
+
+    bench("UndiciHttpHandler – 50 concurrent S3 GetObject", async () => {
+      const tasks = Array.from({ length: 50 }, async () => {
+        const response = await s3WithUndici.send(new GetObjectCommand({ Bucket, Key }));
+        await consumeBody(response);
+      });
+      await Promise.all(tasks);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Run and clean up
+// ---------------------------------------------------------------------------
+
+try {
+  await run();
+} finally {
+  nodeHandler.destroy();
+  undiciHandler.destroy();
+  undiciDispatcher.destroy();
+  s3WithNode.destroy();
+  s3WithUndici.destroy();
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/types/index.d.ts",
   "scripts": {
     "benchmark": "node --expose-gc benchmarks/http-handlers.mjs",
+    "benchmark:s3": "node --expose-gc benchmarks/s3-get-object.mjs",
     "build": "concurrently 'yarn:build:cjs' 'yarn:build:es' 'yarn:build:types'",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",
@@ -35,6 +36,7 @@
     "undici": "^7.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.0.0",
     "@changesets/cli": "^2.31.0",
     "@smithy/node-http-handler": "^4.6.1",
     "@types/node": "^20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,642 @@ __metadata:
   version: 9
   cacheKey: 10c0
 
+"@aws-crypto/crc32@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/crc32@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/eab9581d3363af5ea498ae0e72de792f54d8890360e14a9d8261b7b5c55ebe080279fb2556e07994d785341cdaa99ab0b1ccf137832b53b5904cd6928f2b094b
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32c@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/crc32c@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/223efac396cdebaf5645568fa9a38cd0c322c960ae1f4276bedfe2e1031d0112e49d7d39225d386354680ecefae29f39af469a84b2ddfa77cb6692036188af77
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha1-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/51fed0bf078c10322d910af179871b7d299dde5b5897873ffbeeb036f427e5d11d23db9794439226544b73901920fd19f4d86bbc103ed73cc0cfdea47a83c6ac
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-browser@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/sha256-js": "npm:^5.2.0"
+    "@aws-crypto/supports-web-crypto": "npm:^5.2.0"
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@aws-sdk/util-locate-window": "npm:^3.0.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/05f6d256794df800fe9aef5f52f2ac7415f7f3117d461f85a6aecaa4e29e91527b6fd503681a17136fa89e9dd3d916e9c7e4cfb5eba222875cb6c077bdc1d00d
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:5.2.0, @aws-crypto/sha256-js@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/sha256-js@npm:5.2.0"
+  dependencies:
+    "@aws-crypto/util": "npm:^5.2.0"
+    "@aws-sdk/types": "npm:^3.222.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6c48701f8336341bb104dfde3d0050c89c288051f6b5e9bdfeb8091cf3ffc86efcd5c9e6ff2a4a134406b019c07aca9db608128f8d9267c952578a3108db9fd1
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:5.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4d2118e29d68ca3f5947f1e37ce1fbb3239a0c569cc938cdc8ab8390d595609b5caf51a07c9e0535105b17bf5c52ea256fed705a07e9681118120ab64ee73af2
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:5.2.0, @aws-crypto/util@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@aws-crypto/util@npm:5.2.0"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.222.0"
+    "@smithy/util-utf8": "npm:^2.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0362d4c197b1fd64b423966945130207d1fe23e1bb2878a18e361f7743c8d339dad3f8729895a29aa34fff6a86c65f281cf5167c4bf253f21627ae80b6dd2951
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.0.0":
+  version: 3.1045.0
+  resolution: "@aws-sdk/client-s3@npm:3.1045.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.39"
+    "@aws-sdk/middleware-bucket-endpoint": "npm:^3.972.10"
+    "@aws-sdk/middleware-expect-continue": "npm:^3.972.10"
+    "@aws-sdk/middleware-flexible-checksums": "npm:^3.974.16"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
+    "@aws-sdk/middleware-location-constraint": "npm:^3.972.10"
+    "@aws-sdk/middleware-logger": "npm:^3.972.10"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.37"
+    "@aws-sdk/middleware-ssec": "npm:^3.972.10"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.25"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.14"
+    "@smithy/eventstream-serde-node": "npm:^4.2.14"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/hash-blob-browser": "npm:^4.2.15"
+    "@smithy/hash-node": "npm:^4.2.14"
+    "@smithy/hash-stream-node": "npm:^4.2.14"
+    "@smithy/invalid-dependency": "npm:^4.2.14"
+    "@smithy/md5-js": "npm:^4.2.14"
+    "@smithy/middleware-content-length": "npm:^4.2.14"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-retry": "npm:^4.5.7"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-body-length-node": "npm:^4.2.3"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    "@smithy/util-waiter": "npm:^4.3.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e1c017dd5ee22f57658f0527fcc736e6a240de0e836d49b125b2cde120cd7ff017c7d2e9ac172cca404ffa4c853048079221db068a49ab0faf5e2d6b7a2f93fa
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.974.8":
+  version: 3.974.8
+  resolution: "@aws-sdk/core@npm:3.974.8"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/xml-builder": "npm:^3.972.22"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7b7e01e01e8b5f28b5d1b3d6f263bcf1b395600c2401009ad2b398a39b43ade33eacd59371c1e960c969f8164bfa9aff3ce950a5ba527a73c82eedc21456850f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/crc64-nvme@npm:^3.972.7":
+  version: 3.972.7
+  resolution: "@aws-sdk/crc64-nvme@npm:3.972.7"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c6f23e4e4c06b98009264b511567bb808d4c4f53c1da9b41f5c975f5f9f5e4b11af16e7add850e7bba29731b6efb145eb4dc0538d9639d6a5daaceadb4acf35d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.34":
+  version: 3.972.34
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.34"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2f75940784b92ff71292b6dc5e660982f80bcfb4c3fcd0f0a04b0ff7de0a5b91000505b947434813b1104647d05678c3504560a7937aa82639e0042cb4597705
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.36":
+  version: 3.972.36
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.36"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-stream": "npm:^4.5.25"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b3dd17e4403b3ef026a65da15cc3d08fdfddd42449f6d10edc6a4b016ed05306f7d4fe1fe286abd00bcf6cf3817ed19556fd97db9b2449deb0182569980dcd01
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.36"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.38"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/credential-provider-imds": "npm:^4.2.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/198c7e3f88f525f814f599f6a1bc3a63c84ed046140017786f23de255adcb5c90f0bbcf9ec167c8c6771d63270f7ed9ac061713884ecddebc01da74be88ee6ea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f84ab04b8fec3355dce3d2a0f9bd63e79ef04915f019f2b6731a267e853f7cfb066baf67a22c955e58aa86f5b6eded6acdfdfd67532cc923edeefb8e88f46d63
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.39":
+  version: 3.972.39
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.39"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.36"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.34"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.38"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.38"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/credential-provider-imds": "npm:^4.2.14"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e21808419372f95c842ed6f893d15599565a1fa9dffed81256a374f98ef3a3c276ab4be30fbaac963e5c4761b676fe10482f5a6b1fb2b03273b18e9ecd30c12d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.34":
+  version: 3.972.34
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.34"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f65dbaaa40a81ba8e84d314e8ac0528f6d807b63b98820102ffccb38f47b1aa52f0c6dd4d7e4e8df186cef9cd57041e1d2d929c0e692804a8af0d06497f38a6a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/token-providers": "npm:3.1041.0"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4919362e1b8f6b73b8ec8ed0e0cc8f7a33db9b0d3ef63346a03047a024910d1acc6d80428a51444f6f15d58534dd535bc461b8505dd8f1cd6dc4fd8f863f956d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7a235d693dae5578c15448c8484d68ca7749ffd327b4e3784e3a1c6784a14535b398cc09c6be26e97042779acc261adedc7064681b930d93ebcda26da17c1f72
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-bucket-endpoint@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-arn-parser": "npm:^3.972.3"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-config-provider": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/5529288142e0ebfbd985a257dbbb0f3510981a6ef56ce449465458ca12f7bcbbb9bfba9e1788c925329443604d4a438275f30254ef1d47e7931da798fb6e6765
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-expect-continue@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c91588169621597bed09aa53f9bf858b83a0c8b8b84d6838ed3729c8222a7b7d5819595fd2617ca8f859e8471ca7e7132bb7d1694d5ada17039dea53cc707e4b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:^3.974.16":
+  version: 3.974.16
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.974.16"
+  dependencies:
+    "@aws-crypto/crc32": "npm:5.2.0"
+    "@aws-crypto/crc32c": "npm:5.2.0"
+    "@aws-crypto/util": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/crc64-nvme": "npm:^3.972.7"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/is-array-buffer": "npm:^4.2.2"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/0725e497e2ebd4201682a786b28da90acc9c86459bfd6a3a29591021b7be4e5e17aee2628b71921eba003740d49b88d48eab8bd80220dfc5aa16dc7c50488775
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-host-header@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e631b48f8d8fd40f8977da8d1fc012208f953000dd5645dc0a700c7283af8fafb996c9c1c50e40b8392c402ad98d11e0ddddb949896db5163a7f06e2385e619a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-location-constraint@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ef8ef1f3cf7d28e5b02edcc2b62cab07a380f7a02983bdfcaf24fbea35129c53ac5a1f5846ab28212b649d6c81f437e2a846f1f954fb374509ea174201bf09d4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-logger@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a24e0c98b3cf6c9b7960bf8979d2ab8f839fb89294ba8943136d99dbe7370cc45b010460ed7f5bf14ab6ad8e113ccec6387cf1bda655bcbdb58722df21d9b713
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:^3.972.11":
+  version: 3.972.11
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.972.11"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws/lambda-invoke-store": "npm:^0.2.2"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e52501b00e79e714218897ddec9edd40ecf33fdb43c19b00195c8ed71c8295d0d148f07465465d464f103a23aa535dc1daf60bbb5b95303e330767a5eba78f54
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.37":
+  version: 3.972.37
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.37"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-arn-parser": "npm:^3.972.3"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-config-provider": "npm:^4.2.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c8d4ad6aa908eca70ef085ac2c55362229071caa9518ed538574cc4d317d9f1f4e2173d6b01259dd83f77356ad4b68656b5720a31b3effe01f7fe10aec265aed
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-ssec@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-ssec@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/13e11c485e63d6b3d8a5f14888c6b8aea1c0a96a99826e840840b6974b9605b5f528f8869b021036e8615995d9e5ecd33d6e67af1561ed673d37292d356ca441
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:^3.972.38":
+  version: 3.972.38
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.972.38"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-retry": "npm:^4.3.6"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b9cf9416bc276b4abf42513515de5ee45ee419255b5953c9e53b44010500fcc486de988351683ecae52bf00c6bb5819c67375261afe1375b8a2a44196a8b9884
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.6":
+  version: 3.997.6
+  resolution: "@aws-sdk/nested-clients@npm:3.997.6"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
+    "@aws-sdk/middleware-logger": "npm:^3.972.10"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.25"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/hash-node": "npm:^4.2.14"
+    "@smithy/invalid-dependency": "npm:^4.2.14"
+    "@smithy/middleware-content-length": "npm:^4.2.14"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-retry": "npm:^4.5.7"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-body-length-node": "npm:^4.2.3"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/05c74c7362be74c723b64667763bd1e635c8d566456f70b64fa26546e7c605a49bf1bede7c2f5c293a0677b737093bbdc9b957a26124b9e1de5acf715dc57bb4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/region-config-resolver@npm:^3.972.13":
+  version: 3.972.13
+  resolution: "@aws-sdk/region-config-resolver@npm:3.972.13"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/8cc3e5433ccf9ec4efb6d12ccd924701cfd6fb018124c9e5106486da10402ea1b83b0855353dae5e0f31ad2c7b6d962ac832350a5cdbeda59a30231525fd1118
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.25":
+  version: 3.996.25
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.25"
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.37"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/05196c85d265e5e59df621c7844235a449a940ebc8264578c0f87d76b6fbb741650a5634433589b9223a05003198be214068eef7d6e50596196de0f1d1954b5d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1041.0":
+  version: 3.1041.0
+  resolution: "@aws-sdk/token-providers@npm:3.1041.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/af70f8e23a98a750dcb661b43bbd896e4a2425f553336c491b118a058e46691689ac4fa980f69d2dae42d1488f3b859adbd2f347d73ac1261f44b421d2041101
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.973.8":
+  version: 3.973.8
+  resolution: "@aws-sdk/types@npm:3.973.8"
+  dependencies:
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4823579e7dd0f6dcce9e9fea9630091eb46e3596bc468614a072f682b1eab6f048854ccf5e9398459ada175c13dfc636ffa8c1d3aa655cf6f22447f9c1a02f7f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:^3.972.3":
+  version: 3.972.3
+  resolution: "@aws-sdk/util-arn-parser@npm:3.972.3"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/75c94dcd5d99a60375ce3474b0ee4f1ca17abdcd46ffbf34ce9d2e15238d77903c8993dddd46f1f328a7989c5aaec0c7dfef8b3eaa3e1125bea777399cfc46f2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-endpoints@npm:^3.996.8":
+  version: 3.996.8
+  resolution: "@aws-sdk/util-endpoints@npm:3.996.8"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/66f17e85357ab8e265ab7d1c9a69a064ad3bea99420c786be9ef1f92bc71dca22d328bbceeaf6c64b4a3c37161b78318a3e4a424bf247dcb211d7ae29344db2f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.965.5
+  resolution: "@aws-sdk/util-locate-window@npm:3.965.5"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f5e33a4d7cbfd832ce4bf35b0e532bcabb4084e9b17d45903bccd43f0e221366a423b6acdea8c705ec66b9776f1e624fd640ad716f7446d014e698249d091e83
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/types": "npm:^4.14.1"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e139dda2cb51a0a3553c80ec6f89c39cb1292876c116f8449f21a7fdbe39bd7b545ef8ea69a447dd9fa2aa43c99f625ee6a55cbf6d8e6cf2094d0ef00ceb1e36
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:^3.973.24":
+  version: 3.973.24
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.973.24"
+  dependencies:
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-config-provider": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 10c0/859c6441d1d24594d73a125c2a335faeb412a5cc3ab318005ce2e4904c3f9a0c6781437ae0fb2e3a1eb2343146dafbb9ac037ea88fbd8e78d50f7153732c5bb4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.22":
+  version: 3.972.22
+  resolution: "@aws-sdk/xml-builder@npm:3.972.22"
+  dependencies:
+    "@nodable/entities": "npm:2.1.0"
+    "@smithy/types": "npm:^4.14.1"
+    fast-xml-parser: "npm:5.7.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4d9a7056a8ce6af639a9fa354f70a5a895b2e23c06c027776849d32ba18aa0d7f174133f1bc15756b79ac2bfdb9d990f092fb76a3891a7d1f6b03a424a8a6735
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "@aws/lambda-invoke-store@npm:0.2.4"
+  checksum: 10c0/29d874d7c1a2d971e0c02980594204f89cda718f215f2fc52b6c56eacbdad1fa5f6ce1b358e5811f5cd35d04c76299a67a8aff95318446af2bdfb4910f213e13
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.5.5":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
@@ -342,6 +978,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodable/entities@npm:2.1.0, @nodable/entities@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@nodable/entities@npm:2.1.0"
+  checksum: 10c0/5a4cba2b61a5b6c726328b18b1de6d033cae4a658a118644bf31e0bcbda126ea7b69385043dc556cf1ed859b9ca220e82b81b5e5c48ef1b519fb8ec104575dee
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -492,6 +1135,208 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/config-resolver@npm:^4.4.17":
+  version: 4.5.0
+  resolution: "@smithy/config-resolver@npm:4.5.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d85777a1ee614c4574cf269ace4bde4ebf7dadf2d6bfc853d6e916246cb7679a47056d1a1f91f6c5f4eab01cdadc49a7f56b0c889e4f2e3929a06efbaa8e19ec
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.23.17, @smithy/core@npm:^3.24.0":
+  version: 3.24.0
+  resolution: "@smithy/core@npm:3.24.0"
+  dependencies:
+    "@aws-crypto/crc32": "npm:5.2.0"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f317e449a193e9e12afd76719ea58cdfb316d03fc46e6452b20a089665c86941a76f30e7c7a0bc9e2232334e673d432c08f647ca6651a2c145a33198ec0ee0d6
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/credential-provider-imds@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b3bc4c5f3123dee1043fe3ff22c1c24d8e00cad66f41739a6ab8489d1571167444bd0d4568c3b10ad624adb35c73f39a6fa1cfaf6d830aa3b0dbb4f8c654253c
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-browser@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/eventstream-serde-browser@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a08f3f52a352b7a9011fe9383707f6b2bf13ca62f2aeda38043305acce75e821a8b6cb9779be370ecbae1dc7b8c61b5847aaf425e5ed296cfa8a81a7ff370c97
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-config-resolver@npm:^4.3.14":
+  version: 4.4.0
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/bbfa08ebdd1e85d1fd88cac12718a4a6287f0dd9d07bf28f2c951bc6d9059dca7a1568abee3b87efc929df8d9579b81cdbe730594dde84a6c2aaac791e607b45
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-serde-node@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/eventstream-serde-node@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/6bd23367e6d797f1f1fb56ad59ffdb1bdce0e37bca178ad26a11c7fbefb28b2e0dd9ace39343afb374beb0e20c63185179c0463dd764ffb9a7085fd38247538e
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.3.17":
+  version: 5.4.0
+  resolution: "@smithy/fetch-http-handler@npm:5.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d043f9cf9055eb44da8ac932bc5f04f313a69a43c60bdc5daaf0777ce724fab6f760717c62f385f1d44dc183e1211e333ea673d10c1b5c1afe56a912e17dd800
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-blob-browser@npm:^4.2.15":
+  version: 4.3.0
+  resolution: "@smithy/hash-blob-browser@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a5cfc9e1b46e63f89d54f90acdcebff350b67a179fa6299ab2b95d6486f1f6c5da84817ed4ea50eeb93fae3399f9d8d79c7fa91dc8546eb5901cf20ca5c6a8e2
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-node@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/hash-node@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2b0618a249fb659d5ecb926a1dfa80c91af167e8f762c78704a5cc4150a722c41b0fb7ff8e5f506fcfc7798606fea0f73e80f62e428666c4d03d4be86a6c7ec6
+  languageName: node
+  linkType: hard
+
+"@smithy/hash-stream-node@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/hash-stream-node@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/11dbab69600f54618e95baaf510c462146a8ba08a79351b8328125f11b430bc1792c42c3502c6fe88c36fca4e0fda364dd1a0e265261a6f04e9ef2d95016e6a2
+  languageName: node
+  linkType: hard
+
+"@smithy/invalid-dependency@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/invalid-dependency@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/26a9ffba4d89a05aa71837d4f869d39920de24765542699b980269bf2a4e296d7c02f97ca4c8a3fb8e939100d0209c9d41d5d05c4ff5ea3d0d8f4855437437ef
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/is-array-buffer@npm:2.2.0"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2f2523cd8cc4538131e408eb31664983fecb0c8724956788b015aaf3ab85a0c976b50f4f09b176f1ed7bbe79f3edf80743be7a80a11f22cd9ce1285d77161aaf
+  languageName: node
+  linkType: hard
+
+"@smithy/is-array-buffer@npm:^4.2.2":
+  version: 4.3.0
+  resolution: "@smithy/is-array-buffer@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/091afb4f7b240f30f3a169bc2ceec8d4f398d0a56a6125e1a5df540531f888bcff280d965069464ddc20fafb3bfe14d2f3a66703ae3980abf52ca9a31bdac8b6
+  languageName: node
+  linkType: hard
+
+"@smithy/md5-js@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/md5-js@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/24d33ac9a7b64af46c643602f79756221043e7b982f8db29ddccdf66ca917d0bd44f0a7b83423680eefea0d8a8bea8f11560e317337e92a4a498b7cb52f9a247
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-content-length@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/middleware-content-length@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a21bacf4ea019abdb9aee6d57df8be6f3943ca8f0208a1bb13ba9d77dae60f56391b0201028a5e89b75172c6b01f304ff22c6eb7cb99d62ff52e3c765fde6e51
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-endpoint@npm:^4.4.32":
+  version: 4.5.0
+  resolution: "@smithy/middleware-endpoint@npm:4.5.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7e2dced85eda01cc4590a63d9c9f7c157a8a4bd6c08e6229a37cd68830e8ab0e902e9769fddf2f052bca640c70c911d9ea46300a9de3afbfd3b30f5ba21bec41
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-retry@npm:^4.5.7":
+  version: 4.6.0
+  resolution: "@smithy/middleware-retry@npm:4.6.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/fb94a3643833802e7c54c3e125b381a3445f1f6550355d8283480f13097bfaa9cd79fc77d6cd58dd42a4173430e244a892efbe8118a3aaec3f6fca504c04a5c4
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-serde@npm:^4.2.20":
+  version: 4.3.0
+  resolution: "@smithy/middleware-serde@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e493ac0119d833eb1095ed3fda81e64a68397f64fc978da1390f7fb46d2d027b1caf5278fb47c18c3779ba46a05f6187a6678b204789f8dd9df044b5abbaa410
+  languageName: node
+  linkType: hard
+
+"@smithy/middleware-stack@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/middleware-stack@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/af46e3955eea01fb16110c0b27984dc59eb927980b4b0273f11c7e77523500308fb3d0ad080e3befe5f0df1d4b3ca669dad800dc0cc3f1b7875bbf8a7742d980
+  languageName: node
+  linkType: hard
+
+"@smithy/node-config-provider@npm:^4.3.14":
+  version: 4.4.0
+  resolution: "@smithy/node-config-provider@npm:4.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/30842eedc192179cf7ceb93ae7d1fa28d2fe40417b713e1dcdec927256937d635f9c3167a4e9252f8c6c24450a361be1234e86b30d216477a09f2598bd1caf65
+  languageName: node
+  linkType: hard
+
 "@smithy/node-http-handler@npm:^4.6.1":
   version: 4.6.1
   resolution: "@smithy/node-http-handler@npm:4.6.1"
@@ -501,6 +1346,16 @@ __metadata:
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/6c07fbfd8326cd5369283bd19c1af923ee49b7dcf42fdd199bb7132e4c25eaa6db8573e3b669fb60be0d8f9757a3f2482cd0cf6d6631494255f08239d3036ed2
+  languageName: node
+  linkType: hard
+
+"@smithy/property-provider@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/property-provider@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2d4cc5fd3fd3279a99ff4cbb9d3eba673b83122231a4cb1826254023d7d0fc4cf6973c7c3c57561538c95093822a19bd94e5a55852a6a8e0ca29ae3921832f3a
   languageName: node
   linkType: hard
 
@@ -525,6 +1380,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/shared-ini-file-loader@npm:^4.4.9":
+  version: 4.5.0
+  resolution: "@smithy/shared-ini-file-loader@npm:4.5.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/722c47bf11e99531d6bc1fa2f8c3179f6f0269d95a0b2d49a16e74eadb42c0c78f0bbef27f23665fde4d7760b8a75e1412d00502174ec501927324cff43f74e8
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.3.14":
+  version: 5.4.0
+  resolution: "@smithy/signature-v4@npm:5.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/55763bf28e0a5f6b75b4598713db8abfa3b2588c71d1ca4518fa58321e2f91ae4193fa5a1e2cbe5e0d1c0bfc05d37f9da8b11528af186b27078f3910d5c11ab2
+  languageName: node
+  linkType: hard
+
+"@smithy/smithy-client@npm:^4.12.13":
+  version: 4.13.0
+  resolution: "@smithy/smithy-client@npm:4.13.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2f9aadfcfea48d3892a9ccac66bfb5b335231376d0c9f99d0fa0628ca126a3c6d9aa375db0ce0d28f347a15be49d74c75a8991c097664ebefa630fdd77a20c77
+  languageName: node
+  linkType: hard
+
 "@smithy/types@npm:^4.0.0, @smithy/types@npm:^4.14.1":
   version: 4.14.1
   resolution: "@smithy/types@npm:4.14.1"
@@ -534,12 +1421,162 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/url-parser@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/url-parser@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/41c0a784fb4a7cb2d5ee371900ea543e28d6b144af382c6f5d69cef24f042d67ec9a713a8551ac81c38664f0767fe7feebaf2520121a4ffeca1d0741c80d88cf
+  languageName: node
+  linkType: hard
+
+"@smithy/util-base64@npm:^4.3.2":
+  version: 4.4.0
+  resolution: "@smithy/util-base64@npm:4.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b22850ad39a38b8081a30ea33bee84c384d41eb6424f5b3068f8d05deed5cc8f4f645fe9644867b0a16cd7378cde4a6f01352b74481a127b9e629c1455ca31a7
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-browser@npm:^4.2.2":
+  version: 4.3.0
+  resolution: "@smithy/util-body-length-browser@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/88f0c18db8d8574ce955b697c5335d587680ee30673c01aae7fa96c2c87d09257d967ca734fdf5cea5788a8b4ef9786810dec5c69722a29407877ebeb96846d4
+  languageName: node
+  linkType: hard
+
+"@smithy/util-body-length-node@npm:^4.2.3":
+  version: 4.3.0
+  resolution: "@smithy/util-body-length-node@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/47056e78a72d7d16b681489b9404e45deeb75fa86b684eee1bc0735cad8ee5487b25e7438eb7d3b28df597e98400ef4878e39274fd606d1765ffa5591ca46c5f
+  languageName: node
+  linkType: hard
+
+"@smithy/util-buffer-from@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@smithy/util-buffer-from@npm:2.2.0"
+  dependencies:
+    "@smithy/is-array-buffer": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/223d6a508b52ff236eea01cddc062b7652d859dd01d457a4e50365af3de1e24a05f756e19433f6ccf1538544076b4215469e21a4ea83dc1d58d829725b0dbc5a
+  languageName: node
+  linkType: hard
+
+"@smithy/util-config-provider@npm:^4.2.2":
+  version: 4.3.0
+  resolution: "@smithy/util-config-provider@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/7a88a7dedd3a68564c0aec73bdc1e1a7b385fd3aab61188a997294435f7514ff49b4710c01dd515474fe7ffadb1b0d444319d9144c6023760fd935dfe3df0321
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-browser@npm:^4.3.49":
+  version: 4.4.0
+  resolution: "@smithy/util-defaults-mode-browser@npm:4.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d85bae5eeeda85db720426490a079802f9432dd06b4bf8b0475deca1b3d8c724e8eee947fab9d6aa2a048a321a7ed393405c9bab7a992bf86b603f473de718da
+  languageName: node
+  linkType: hard
+
+"@smithy/util-defaults-mode-node@npm:^4.2.54":
+  version: 4.3.0
+  resolution: "@smithy/util-defaults-mode-node@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a22cd4a14e79a9eb8ac30d59a78f165977ac755adc7851cec084efdafc29918af1075fb5c7398577871d26bdab4c53650182fc887eb48e07b7b0da896d7efa64
+  languageName: node
+  linkType: hard
+
+"@smithy/util-endpoints@npm:^3.4.2":
+  version: 3.5.0
+  resolution: "@smithy/util-endpoints@npm:3.5.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b1598ad5424b4648be5df8f3ddea99c02b301cac56445ffd7fff66dca7f3a851578c86c9bb0b3e3332589103fc823a7f0a14157683de19b02d76fd299241cb04
+  languageName: node
+  linkType: hard
+
+"@smithy/util-middleware@npm:^4.2.14":
+  version: 4.3.0
+  resolution: "@smithy/util-middleware@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9fbd24674413a275768c323cb03f83f82c24a127026c31c58e1448b61ed9179a0473279f63c73a158b424ae11b0c268892b2a0546db7ce290d2d3c40af56a6eb
+  languageName: node
+  linkType: hard
+
+"@smithy/util-retry@npm:^4.3.6":
+  version: 4.4.0
+  resolution: "@smithy/util-retry@npm:4.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c4e3a31331234f55f7473ad6c7165ff6f6a456b53f3a641e934bd8fa4591cf0fc2bc6a1c14a0ba44a5a9bb4565e7de61eccb2e5b5fb10dcf6dd61bdf71e2e8a8
+  languageName: node
+  linkType: hard
+
+"@smithy/util-stream@npm:^4.5.25":
+  version: 4.6.0
+  resolution: "@smithy/util-stream@npm:4.6.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/283ae66729690496a191bc92726f8423acbad6773622fa93293d14263d90845b32a9bff68369b08fe35a5875a06d9c8828621a125126738bc59a2834d6fd4f4e
+  languageName: node
+  linkType: hard
+
 "@smithy/util-uri-escape@npm:^4.2.2":
   version: 4.2.2
   resolution: "@smithy/util-uri-escape@npm:4.2.2"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/33b6546086c975278d16b5029e6555df551b4bd1e3a84042544d1ef956a287fe033b317954b1737b2773e82b6f27ebde542956ff79ef0e8a813dc0dbf9d34a58
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^2.0.0":
+  version: 2.3.0
+  resolution: "@smithy/util-utf8@npm:2.3.0"
+  dependencies:
+    "@smithy/util-buffer-from": "npm:^2.2.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e18840c58cc507ca57fdd624302aefd13337ee982754c9aa688463ffcae598c08461e8620e9852a424d662ffa948fc64919e852508028d09e89ced459bd506ab
+  languageName: node
+  linkType: hard
+
+"@smithy/util-utf8@npm:^4.2.2":
+  version: 4.3.0
+  resolution: "@smithy/util-utf8@npm:4.3.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/80df3505b2e3e2d974ab2496dc3ad3a512cb0129dce0ab59cd4d44d89b69aba82a8a9188dc4614e528ed385c49de10a32bf856a779761e1b50a845e994e2beaf
+  languageName: node
+  linkType: hard
+
+"@smithy/util-waiter@npm:^4.3.0":
+  version: 4.4.0
+  resolution: "@smithy/util-waiter@npm:4.4.0"
+  dependencies:
+    "@smithy/core": "npm:^3.24.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/f04d481d880ffaf18014ccaae6e776c0f39b0bd85f74620b5059d73183e81296ded8c8466033f1fb10d28f70b21f00edff8f25b270da06a5eecb9ac2a45a513a
   languageName: node
   linkType: hard
 
@@ -554,6 +1591,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trivikr-test/undici-http-handler@workspace:."
   dependencies:
+    "@aws-sdk/client-s3": "npm:^3.0.0"
     "@changesets/cli": "npm:^2.31.0"
     "@smithy/node-http-handler": "npm:^4.6.1"
     "@smithy/protocol-http": "npm:^5.0.0"
@@ -766,6 +1804,13 @@ __metadata:
   dependencies:
     is-windows: "npm:^1.0.0"
   checksum: 10c0/7335130729d59a14b8e4753fea180ca84e287cccc20cb5f2438a95667abc5810327c414eee7b3c79ed1b5a348a40284ea872958f50caba69432c40405eb0acce
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 10c0/bb69b55ba7f0456e3dc07d0cfd9467f985581f640ba8fd426b08754a6737ee0d6cf3b50607941e5255f04c83075b952ece0599f978dd4d20f1e95461104c5ffd
   languageName: node
   linkType: hard
 
@@ -982,6 +2027,30 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.8"
   checksum: 10c0/f6aaa141d0d3384cf73cbcdfc52f475ed293f6d5b65bfc5def368b09163a9f7e5ec2b3014d80f733c405f58e470ee0cc451c2937685045cddcdeaa24199c43fe
+  languageName: node
+  linkType: hard
+
+"fast-xml-builder@npm:^1.1.5":
+  version: 1.2.0
+  resolution: "fast-xml-builder@npm:1.2.0"
+  dependencies:
+    path-expression-matcher: "npm:^1.5.0"
+    xml-naming: "npm:^0.1.0"
+  checksum: 10c0/84bb105cd04e91d6dcb746c4dbaeb12903b510e7ab9a06ffde55b5a582e005559a87d84467f18a655c6c4baf098f696fd74cee3cbe1aea9d01385907768ba32d
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:5.7.2":
+  version: 5.7.2
+  resolution: "fast-xml-parser@npm:5.7.2"
+  dependencies:
+    "@nodable/entities": "npm:^2.1.0"
+    fast-xml-builder: "npm:^1.1.5"
+    path-expression-matcher: "npm:^1.5.0"
+    strnum: "npm:^2.2.3"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10c0/d48439ce0700add82f5e7c6ccc5a1f06483beb7cd8e88caa83c6406843e52f14988e60d05cbb3a86ffe07e073807674c807e0764d94a280e1c96d7e2011dae8e
   languageName: node
   linkType: hard
 
@@ -1533,6 +2602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 10c0/646cb5bc66cd7d809a52288336f3ac1e6223f156fd8e912936e490e590f7f93e8056d4fd25fcbcc7da61bb698fa520112cb050372a3f65e7b79bd4afa0f77610
+  languageName: node
+  linkType: hard
+
 "path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
@@ -1857,6 +2933,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strnum@npm:^2.2.3":
+  version: 2.3.0
+  resolution: "strnum@npm:2.3.0"
+  checksum: 10c0/8d29ea0789df22dfa6101153573c76ce12fb065ed0807eb99cc64624cd7f3d67a5aa0db507e75ab985ca23908cc4f02c65f3359ad762cb3659e3d6456e76e143
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
@@ -2166,6 +3249,13 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 10c0/8c7614865361bcb7e53e3e091dac21c567e2b92d447919b2f072775aa9dcfc94a5255bd52fbaa0fd53c93513e53a23a6a835218ad2af512451dbc678392f85fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tested on [c7g.4xlarge](https://aws.amazon.com/ec2/instance-types/c7g/)

```console
benchmark                                           avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------------------------------- -------------------------------
NodeHttpHandler  – serial GetObject (all sizes)      576.79 ms/iter 629.11 ms   █ █                
                                            (515.27 ms … 676.09 ms) 672.88 ms ▅▅█▅█ ▅       ▅  ▅  ▅
                                            (393.32 kb …   5.68 mb)   1.91 mb █████▁█▁▁▁▁▁▁▁█▁▁█▁▁█

UndiciHttpHandler – serial GetObject (all sizes)     536.68 ms/iter 531.21 ms      ██ █            
                                            (498.37 ms … 593.94 ms) 585.14 ms ▅   ▅██▅█       ▅   ▅
                                            (  1.59 mb …  15.39 mb)  11.32 mb █▁▁▁█████▁▁▁▁▁▁▁█▁▁▁█

                                                     ┌                                            ┐
                                                         ╷   ┌───────────┬─────────────┐          ╷
     NodeHttpHandler  – serial GetObject (all sizes)     ├───┤           │             ├──────────┤
                                                         ╵   └───────────┴─────────────┘          ╵
                                                     ╷    ┌────┬           ╷
    UndiciHttpHandler – serial GetObject (all sizes) ├────┤    │───────────┤
                                                     ╵    └────┴           ╵
                                                     └                                            ┘
                                                     498.37 ms         585.63 ms          672.88 ms

summary
  UndiciHttpHandler – serial GetObject (all sizes)
   1.07x faster than NodeHttpHandler  – serial GetObject (all sizes)

------------------------------------------------------------------- -------------------------------
NodeHttpHandler  – concurrent GetObject (all sizes)  176.24 ms/iter 175.50 ms ██          █        
                                            (174.25 ms … 189.70 ms) 176.32 ms ██ ▅  ▅▅    █      ▅▅
                                            (404.21 kb …   8.90 mb)   3.38 mb ██▁█▁▁██▁▁▁▁█▁▁▁▁▁▁██

UndiciHttpHandler – concurrent GetObject (all sizes) 175.94 ms/iter 175.12 ms   █      █           
                                            (173.53 ms … 189.50 ms) 177.01 ms ▅▅█▅▅▅   █         ▅▅
                                            (  1.28 mb …  14.36 mb)   8.20 mb ██████▁▁▁█▁▁▁▁▁▁▁▁▁██

                                                     ┌                                            ┐
                                                              ╷┌────────────────────────┬╷
 NodeHttpHandler  – concurrent GetObject (all sizes)          ├┤                        │┤
                                                              ╵└────────────────────────┴╵
                                                     ╷    ┌─────────────────────────┬             ╷
UndiciHttpHandler – concurrent GetObject (all sizes) ├────┤                         │─────────────┤
                                                     ╵    └─────────────────────────┴             ╵
                                                     └                                            ┘
                                                     173.53 ms         175.27 ms          177.01 ms

summary
  UndiciHttpHandler – concurrent GetObject (all sizes)
   1x faster than NodeHttpHandler  – concurrent GetObject (all sizes)
```