### PR TITLE
chore: remove redundant code from UndiciHttpHandler

### DIFF
--- a/.changeset/grumpy-carpets-double.md
+++ b/.changeset/grumpy-carpets-double.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": minor
+---
+
+Remove `static create()` factory method and async config provider

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -119,14 +119,6 @@ describe("UndiciHttpHandler", () => {
       expect(handler.metadata).toEqual({ handlerProtocol: "http/1.1" });
     });
 
-    it("creates a new instance with a provider function", async () => {
-      handler = new UndiciHttpHandler(async () => ({
-        logger: createMockLogger(),
-      }));
-      const { response } = await handler.handle(createMockRequest());
-      expect(response.statusCode).toBe(200);
-    });
-
   });
 
   describe("handle", () => {
@@ -474,17 +466,10 @@ describe("UndiciHttpHandler", () => {
   });
 
   describe("updateHttpClientConfig / httpHandlerConfigs", () => {
-    it("returns config before first request when options are synchronous", () => {
+    it("returns config before first request", () => {
       const logger = createMockLogger();
       handler = new UndiciHttpHandler({ logger });
       expect(handler.httpHandlerConfigs()).toEqual({ logger });
-    });
-
-    it("returns empty object before first request when options are async", () => {
-      handler = new UndiciHttpHandler(async () => ({
-        logger: createMockLogger(),
-      }));
-      expect(handler.httpHandlerConfigs()).toEqual({});
     });
 
     it("returns config after first request", async () => {

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -127,23 +127,6 @@ describe("UndiciHttpHandler", () => {
       expect(response.statusCode).toBe(200);
     });
 
-    it("static create returns existing HttpHandler instance", () => {
-      handler = new UndiciHttpHandler();
-      const result = UndiciHttpHandler.create(handler);
-      expect(result).toBe(handler);
-    });
-
-    it("static create instantiates from options", () => {
-      const result = UndiciHttpHandler.create({ logger: createMockLogger() });
-      expect(result).toBeInstanceOf(UndiciHttpHandler);
-      handler = result as UndiciHttpHandler;
-    });
-
-    it("static create instantiates with no arguments", () => {
-      const result = UndiciHttpHandler.create();
-      expect(result).toBeInstanceOf(UndiciHttpHandler);
-      handler = result as UndiciHttpHandler;
-    });
   });
 
   describe("handle", () => {

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -1,7 +1,7 @@
 import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
 import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
-import type { HttpHandlerOptions, Logger, Provider } from "@smithy/types";
+import type { HttpHandlerOptions, Logger } from "@smithy/types";
 import { Agent, Dispatcher } from "undici";
 
 /**
@@ -26,40 +26,18 @@ export interface UndiciHttpHandlerOptions {
 export class UndiciHttpHandler
   implements HttpHandler<UndiciHttpHandlerOptions>
 {
-  private config?: UndiciHttpHandlerOptions;
-  private configProvider: Promise<UndiciHttpHandlerOptions>;
+  private config: UndiciHttpHandlerOptions;
   private dispatcher?: Dispatcher;
   private externalDispatcher = false;
 
   public readonly metadata = { handlerProtocol: "http/1.1" };
 
-  constructor(
-    options?:
-      | UndiciHttpHandlerOptions
-      | Provider<UndiciHttpHandlerOptions | void>,
-  ) {
-    if (typeof options === "function") {
-      this.configProvider = options().then((_options) =>
-        this.resolveConfig(_options),
-      );
-    } else {
-      // Synchronous path: resolve config immediately and cache a
-      // pre-settled promise so the first handle() avoids a microtask.
-      const resolved = this.resolveConfig(options);
-      this.config = resolved;
-      this.configProvider = Promise.resolve(resolved);
-    }
-  }
-
-  private resolveConfig(
-    options?: UndiciHttpHandlerOptions | void,
-  ): UndiciHttpHandlerOptions {
-    const resolved: UndiciHttpHandlerOptions = { ...options };
-    if (resolved.dispatcher) {
+  constructor(options?: UndiciHttpHandlerOptions) {
+    this.config = { ...options };
+    if (this.config.dispatcher) {
       this.externalDispatcher = true;
-      this.dispatcher = resolved.dispatcher;
+      this.dispatcher = this.config.dispatcher;
     }
-    return resolved;
   }
 
   private getOrCreateDispatcher(): Dispatcher {
@@ -83,10 +61,6 @@ export class UndiciHttpHandler
     request: HttpRequest,
     { abortSignal, requestTimeout }: HttpHandlerOptions = {},
   ): Promise<{ response: HttpResponse }> {
-    if (!this.config) {
-      this.config = await this.configProvider;
-    }
-
     const dispatcher = this.getOrCreateDispatcher();
 
     if (abortSignal?.aborted) {
@@ -187,26 +161,21 @@ export class UndiciHttpHandler
     key: keyof UndiciHttpHandlerOptions,
     value: UndiciHttpHandlerOptions[typeof key],
   ): void {
-    this.config = undefined;
-    this.configProvider = this.configProvider.then((config) => {
-      const updated = { ...config, [key]: value };
+    (this.config as any)[key] = value;
 
-      if (key === "dispatcher") {
-        // Tear down the old internal dispatcher before switching.
-        if (this.dispatcher && !this.externalDispatcher) {
-          this.dispatcher.destroy();
-        }
-        if (value) {
-          this.dispatcher = value as Dispatcher;
-          this.externalDispatcher = true;
-        } else {
-          this.dispatcher = undefined;
-          this.externalDispatcher = false;
-        }
+    if (key === "dispatcher") {
+      // Tear down the old internal dispatcher before switching.
+      if (this.dispatcher && !this.externalDispatcher) {
+        this.dispatcher.destroy();
       }
-
-      return updated;
-    });
+      if (value) {
+        this.dispatcher = value as Dispatcher;
+        this.externalDispatcher = true;
+      } else {
+        this.dispatcher = undefined;
+        this.externalDispatcher = false;
+      }
+    }
   }
 
   public httpHandlerConfigs(): UndiciHttpHandlerOptions {

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -33,22 +33,6 @@ export class UndiciHttpHandler
 
   public readonly metadata = { handlerProtocol: "http/1.1" };
 
-  /**
-   * Returns the input if it is an HttpHandler of any class,
-   * or instantiates a new instance of this handler.
-   */
-  public static create(
-    instanceOrOptions?:
-      | HttpHandler<any>
-      | UndiciHttpHandlerOptions
-      | Provider<UndiciHttpHandlerOptions | void>,
-  ) {
-    if (typeof (instanceOrOptions as any)?.handle === "function") {
-      return instanceOrOptions as HttpHandler<any>;
-    }
-    return new UndiciHttpHandler(instanceOrOptions as UndiciHttpHandlerOptions);
-  }
-
   constructor(
     options?:
       | UndiciHttpHandlerOptions

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -27,7 +27,6 @@ export class UndiciHttpHandler
   implements HttpHandler<UndiciHttpHandlerOptions>
 {
   private config: UndiciHttpHandlerOptions;
-  private dispatcher?: Dispatcher;
   private externalDispatcher = false;
 
   public readonly metadata = { handlerProtocol: "http/1.1" };
@@ -36,24 +35,23 @@ export class UndiciHttpHandler
     this.config = { ...options };
     if (this.config.dispatcher) {
       this.externalDispatcher = true;
-      this.dispatcher = this.config.dispatcher;
     }
   }
 
   private getOrCreateDispatcher(): Dispatcher {
-    if (this.dispatcher) {
-      return this.dispatcher;
+    if (this.config.dispatcher) {
+      return this.config.dispatcher;
     }
 
-    this.dispatcher = new Agent();
+    this.config.dispatcher = new Agent();
 
-    return this.dispatcher;
+    return this.config.dispatcher;
   }
 
   public destroy(): void {
-    if (this.dispatcher && !this.externalDispatcher) {
-      this.dispatcher.destroy();
-      this.dispatcher = undefined;
+    if (this.config.dispatcher && !this.externalDispatcher) {
+      this.config.dispatcher.destroy();
+      this.config.dispatcher = undefined;
     }
   }
 
@@ -165,14 +163,12 @@ export class UndiciHttpHandler
 
     if (key === "dispatcher") {
       // Tear down the old internal dispatcher before switching.
-      if (this.dispatcher && !this.externalDispatcher) {
-        this.dispatcher.destroy();
+      if (this.config.dispatcher && !this.externalDispatcher) {
+        this.config.dispatcher.destroy();
       }
       if (value) {
-        this.dispatcher = value as Dispatcher;
         this.externalDispatcher = true;
       } else {
-        this.dispatcher = undefined;
         this.externalDispatcher = false;
       }
     }


### PR DESCRIPTION
Removes the code which is not required as per `HttpHandler` interface
* The static `create` function
  * It was added in NodeHttpHandler to allow passing options in https://github.com/smithy-lang/smithy-typescript/pull/1089
  * Since `UndiciHttpHandler` won't be included by default and users will have to explicitly import and pass it, this option is not needed. 
* Stop accepting `configProvider` in constructor
  * The `configProvider` was added in NodeHttpHandler to support [smart configuration defaults](https://docs.aws.amazon.com/sdkref/latest/guide/feature-smart-config-defaults.html). They're not needed in UndiciHttpHandler, as users will provide their values, if needed.
* Remove redundant `this.dispatcher`