### PR TITLE
test(e2e): event stream with cloudwatch-logs startLiveTail

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build:types": "tsc -p tsconfig.types.json",
     "test": "vitest run",
+    "test:e2e": "vitest run -c vitest.config.e2e.mts",
     "clean": "rm -rf dist",
     "release": "yarn build && changeset publish"
   },
@@ -35,6 +36,7 @@
     "undici": "^7.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.1045.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@changesets/cli": "^2.31.0",
     "@smithy/node-http-handler": "^4.6.1",

--- a/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
+++ b/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from "node:crypto";
+
+import { CloudWatchLogs } from "@aws-sdk/client-cloudwatch-logs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { UndiciHttpHandler } from "./undici-http-handler";
+
+describe("UndiciHttpHandler CloudWatch Logs e2e", () => {
+  const logGroupName = `/test/undici-http-handler/${randomUUID()}`;
+  const logStreamName = "test-stream";
+  const client = new CloudWatchLogs({
+    requestHandler: new UndiciHttpHandler(),
+  });
+  let logGroupArn: string;
+
+  beforeAll(async () => {
+    await client.createLogGroup({ logGroupName });
+    await client.createLogStream({ logGroupName, logStreamName });
+
+    const { logGroups } = await client.describeLogGroups({
+      logGroupNamePrefix: logGroupName,
+    });
+    // The ARN from describeLogGroups ends with ":*", which startLiveTail doesn't accept.
+    logGroupArn = logGroups![0].arn!.replace(/:?\*$/, "");
+  });
+
+  afterAll(async () => {
+    await client.deleteLogStream({ logGroupName, logStreamName });
+    await client.deleteLogGroup({ logGroupName });
+    client.destroy();
+  });
+
+  it("startLiveTail", { timeout: 60_000 }, async () => {
+    expect.assertions(3);
+    const testMessage = "test message";
+
+    const response = await client.startLiveTail({
+      logGroupIdentifiers: [logGroupArn],
+    });
+
+    expect(response.$metadata.httpStatusCode).toBe(200);
+    expect(response.responseStream).toBeDefined();
+
+    // Put log events AFTER starting the live tail so they appear in the stream
+    const putEventsPromise = async () => {
+      // Wait for the live tail session to establish before putting events
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await client.putLogEvents({
+        logGroupName,
+        logStreamName,
+        logEvents: [{ timestamp: Date.now(), message: testMessage }],
+      });
+    };
+
+    const consumeStreamPromise = async () => {
+      for await (const event of response.responseStream!) {
+        if (event.sessionStart) {
+          expect(event.sessionStart.logGroupIdentifiers).toContain(logGroupArn);
+        }
+        if (event.sessionUpdate) {
+          const messages =
+            event.sessionUpdate.sessionResults?.map((r) => r.message) ?? [];
+          if (messages.includes(testMessage)) {
+            break;
+          }
+        }
+      }
+    };
+
+    await Promise.all([putEventsPromise(), consumeStreamPromise()]);
+  });
+});

--- a/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
+++ b/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
@@ -31,7 +31,7 @@ describe("UndiciHttpHandler CloudWatch Logs e2e", () => {
   });
 
   it("startLiveTail", { timeout: 60_000 }, async () => {
-    expect.assertions(3);
+    expect.assertions(4);
     const testMessage = "test message";
 
     const response = await client.startLiveTail({
@@ -61,6 +61,7 @@ describe("UndiciHttpHandler CloudWatch Logs e2e", () => {
           const messages =
             event.sessionUpdate.sessionResults?.map((r) => r.message) ?? [];
           if (messages.includes(testMessage)) {
+            expect(messages).toContain(testMessage);
             break;
           }
         }

--- a/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
+++ b/src/undici-http-handler.cloudwatch-logs.e2e.spec.ts
@@ -25,8 +25,10 @@ describe("UndiciHttpHandler CloudWatch Logs e2e", () => {
   });
 
   afterAll(async () => {
-    await client.deleteLogStream({ logGroupName, logStreamName });
-    await client.deleteLogGroup({ logGroupName });
+    await client
+      .deleteLogStream({ logGroupName, logStreamName })
+      .catch(() => {});
+    await client.deleteLogGroup({ logGroupName }).catch(() => {});
     client.destroy();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-cloudwatch-logs@npm:^3.1045.0":
+  version: 3.1045.0
+  resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.1045.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.39"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
+    "@aws-sdk/middleware-logger": "npm:^3.972.10"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.14"
+    "@smithy/eventstream-serde-node": "npm:^4.2.14"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/hash-node": "npm:^4.2.14"
+    "@smithy/invalid-dependency": "npm:^4.2.14"
+    "@smithy/middleware-content-length": "npm:^4.2.14"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-retry": "npm:^4.5.7"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-body-length-node": "npm:^4.2.3"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/be639e418924cd0286ff79fc4163c85456e97eb14bb9b293281655b9df424d6e7eec46d101a3ed43ff0bacec59b13f8e9ffc1a80f7fd19662bc8065d50e84f7c
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-s3@npm:^3.0.0":
   version: 3.1045.0
   resolution: "@aws-sdk/client-s3@npm:3.1045.0"
@@ -1591,6 +1641,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trivikr-test/undici-http-handler@workspace:."
   dependencies:
+    "@aws-sdk/client-cloudwatch-logs": "npm:^3.1045.0"
     "@aws-sdk/client-s3": "npm:^3.0.0"
     "@changesets/cli": "npm:^2.31.0"
     "@smithy/node-http-handler": "npm:^4.6.1"


### PR DESCRIPTION
This test code will move into `@aws-sdk/*` in future

```console
$ yarn vitest src/undici-http-handler.cloudwatch-logs.e2e.spec.ts -c vitest.config.e2e.mts

 RUN  v4.1.5 /local/home/trivikr/workspace/trivikr-test-undici-http-handler

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  22:16:58
   Duration  3.69s (transform 25ms, setup 0ms, import 111ms, tests 3.46s, environment 0ms)
```