### PR TITLE
 fix: exclude test files in compilation

### DIFF
--- a/.changeset/lovely-dryers-drive.md
+++ b/.changeset/lovely-dryers-drive.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": patch
+---
+
+Exclude test files in compilation

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "declaration": false
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.spec.ts"]
 }


### PR DESCRIPTION
Refs: https://github.com/trivikr/trivikr-test-undici-http-handler/compare/exclude-test-files?expand=1

#### Before

```console
$ ls dist/cjs 
index.js  undici-http-handler.js  undici-http-handler.s3.e2e.spec.js  undici-http-handler.spec.js
```

#### After

```console
$ ls dist/cjs 
index.js  undici-http-handler.js
```