### PR TITLE
fix: support streaming body in UndiciHttpHandler

### DIFF
--- a/.changeset/mighty-cobras-enjoy.md
+++ b/.changeset/mighty-cobras-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": patch
+---
+
+Support streaming body in UndiciHttpHandler

--- a/src/request-handler.s3.e2e.spec.ts
+++ b/src/request-handler.s3.e2e.spec.ts
@@ -60,6 +60,8 @@ describe.each([
       Bucket: bucketName,
       Key: key,
       Body: body,
+      // ContentLength is required for streaming bodies (Readable) because handler cannot
+      // determine the content length of a stream on its own, unlike string or Buffer bodies.
       ...(body instanceof Readable && { ContentLength: expected.length }),
     });
     expect(putResponse.$metadata.httpStatusCode).toBe(200);

--- a/src/request-handler.s3.e2e.spec.ts
+++ b/src/request-handler.s3.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { randomBytes, randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
 
 import { S3 } from "@aws-sdk/client-s3";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -35,13 +36,19 @@ describe.each([
     client.destroy();
   });
 
-  it("list/head/put/get/delete", async () => {
-    const key = "test-object";
-    const body = randomBytes(16 * 1024); // 16 KB of random data
+  const data = randomBytes(16 * 1024); // 16 KB of random data
 
-    // listObjectsV2 should return empty before put
-    const listBeforePut = await client.listObjectsV2({ Bucket: bucketName });
-    expect(listBeforePut.Contents).toBeUndefined();
+  it.each([
+    {
+      type: "string",
+      body: data.toString("base64"),
+      expected: Buffer.from(data.toString("base64")),
+    },
+    { type: "Uint8Array", body: new Uint8Array(data), expected: data },
+    { type: "Buffer", body: data, expected: data },
+    { type: "Readable", body: Readable.from(data), expected: data },
+  ])("put/get/delete with body as $type", async ({ body, expected }) => {
+    const key = `test-object-${randomUUID()}`;
 
     // headObject should fail before put
     await expect(
@@ -56,18 +63,6 @@ describe.each([
     });
     expect(putResponse.$metadata.httpStatusCode).toBe(200);
 
-    // listObjectsV2 should contain the key after put
-    const listAfterPut = await client.listObjectsV2({ Bucket: bucketName });
-    expect(listAfterPut.Contents).toHaveLength(1);
-    expect(listAfterPut.Contents![0].Key).toBe(key);
-
-    // headObject should succeed after put
-    const headResponse = await client.headObject({
-      Bucket: bucketName,
-      Key: key,
-    });
-    expect(headResponse.$metadata.httpStatusCode).toBe(200);
-
     // Get the object
     const getResponse = await client.getObject({
       Bucket: bucketName,
@@ -76,7 +71,7 @@ describe.each([
     expect(getResponse.$metadata.httpStatusCode).toBe(200);
 
     const receivedBody = await getResponse.Body!.transformToByteArray();
-    expect(Buffer.from(receivedBody)).toEqual(body);
+    expect(Buffer.from(receivedBody)).toEqual(expected);
 
     // Delete the object
     const deleteResponse = await client.deleteObject({

--- a/src/request-handler.s3.e2e.spec.ts
+++ b/src/request-handler.s3.e2e.spec.ts
@@ -60,6 +60,7 @@ describe.each([
       Bucket: bucketName,
       Key: key,
       Body: body,
+      ...(body instanceof Readable && { ContentLength: expected.length }),
     });
     expect(putResponse.$metadata.httpStatusCode).toBe(200);
 

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -118,7 +118,6 @@ describe("UndiciHttpHandler", () => {
       handler = new UndiciHttpHandler({ logger: createMockLogger() });
       expect(handler.metadata).toEqual({ handlerProtocol: "http/1.1" });
     });
-
   });
 
   describe("handle", () => {
@@ -396,57 +395,70 @@ describe("UndiciHttpHandler", () => {
   });
 
   describe("expect header", () => {
-    it("strips Expect header before sending to undici", async () => {
-      const mockDispatcher = {
-        request: vi.fn().mockResolvedValue({
-          statusCode: 200,
-          headers: {},
-          body: null,
-        }),
-        destroy: vi.fn(),
-      } as unknown as Dispatcher;
+    it.each(["expect", "Expect"])(
+      "strips '%s' header before sending to undici",
+      async (expectHeader) => {
+        const mockDispatcher = {
+          request: vi.fn().mockResolvedValue({
+            statusCode: 200,
+            headers: {},
+            body: null,
+          }),
+          destroy: vi.fn(),
+        } as unknown as Dispatcher;
 
-      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
-      await handler.handle(
-        createMockRequest({
-          method: "PUT",
-          headers: {
-            "content-type": "application/octet-stream",
-            Expect: "100-continue",
-          },
-        }),
-      );
+        handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+        await handler.handle(
+          createMockRequest({
+            method: "PUT",
+            headers: {
+              "content-type": "application/octet-stream",
+              [expectHeader]: "100-continue",
+            },
+          }),
+        );
 
-      const callArgs = (mockDispatcher.request as any).mock.calls[0][0];
-      expect(callArgs.headers).not.toHaveProperty("Expect");
-      expect(callArgs.headers).not.toHaveProperty("expect");
-    });
+        const callArgs = (mockDispatcher.request as any).mock.calls[0][0];
+        expect(callArgs.headers).not.toHaveProperty(expectHeader);
+      },
+    );
+  });
 
-    it("strips lowercase expect header", async () => {
-      const mockDispatcher = {
-        request: vi.fn().mockResolvedValue({
-          statusCode: 200,
-          headers: {},
-          body: null,
-        }),
-        destroy: vi.fn(),
-      } as unknown as Dispatcher;
+  describe("transfer-encoding header", () => {
+    it.each(["transfer-encoding", "Transfer-Encoding"])(
+      "strips '%s' header when body is a stream",
+      async (transferEncodingHeader) => {
+        const mockDispatcher = {
+          request: vi.fn().mockResolvedValue({
+            statusCode: 200,
+            headers: {},
+            body: null,
+          }),
+          destroy: vi.fn(),
+        } as unknown as Dispatcher;
 
-      handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
-      await handler.handle(
-        createMockRequest({
-          method: "PUT",
-          headers: {
-            "content-type": "application/octet-stream",
-            expect: "100-continue",
-          },
-        }),
-      );
+        // Duck-type a stream-like body (has pipe and on methods)
+        const streamBody = {
+          pipe: vi.fn(),
+          on: vi.fn(),
+        };
 
-      const callArgs = (mockDispatcher.request as any).mock.calls[0][0];
-      expect(callArgs.headers).not.toHaveProperty("Expect");
-      expect(callArgs.headers).not.toHaveProperty("expect");
-    });
+        handler = new UndiciHttpHandler({ dispatcher: mockDispatcher });
+        await handler.handle(
+          createMockRequest({
+            method: "PUT",
+            headers: {
+              "content-type": "application/octet-stream",
+              [transferEncodingHeader]: "chunked",
+            },
+            body: streamBody as any,
+          }),
+        );
+
+        const callArgs = (mockDispatcher.request as any).mock.calls[0][0];
+        expect(callArgs.headers).not.toHaveProperty(transferEncodingHeader);
+      },
+    );
   });
 
   describe("destroy", () => {

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -1,3 +1,5 @@
+import type { Readable } from "node:stream";
+
 import type { HttpHandler, HttpRequest } from "@smithy/protocol-http";
 import { HttpResponse } from "@smithy/protocol-http";
 import { buildQueryString } from "@smithy/querystring-builder";
@@ -95,6 +97,20 @@ export class UndiciHttpHandler
     const headers = request.headers;
     if ("Expect" in headers) delete headers["Expect"];
     if ("expect" in headers) delete headers["expect"];
+
+    // Strip transfer-encoding header for streaming bodies — undici manages
+    // chunked encoding internally for streams, so the explicit header is not
+    // needed and causes issues with content-length negotiation.
+    // Uses the same duck-typing check as undici's isStream (pipe + on).
+    const body = request.body as Readable | undefined;
+    if (
+      body &&
+      typeof body.pipe === "function" &&
+      typeof body.on === "function"
+    ) {
+      if ("transfer-encoding" in headers) delete headers["transfer-encoding"];
+      if ("Transfer-Encoding" in headers) delete headers["Transfer-Encoding"];
+    }
 
     const headersTimeout =
       requestTimeout !== undefined ? requestTimeout || undefined : undefined;


### PR DESCRIPTION
Undici manages chunked encoding internally for streams, so the explicit transfer-encoding header set by the SDK triggers the aws-chunked content-length middleware to set x-amz-decoded-content-length to undefined.

This PR strips the header only when the body is a stream, using the same duck-typing check as undici's isStream (pipe + on).

E2E tests are successful
```console
$ yarn vitest src/request-handler.s3.e2e.spec.ts -c vitest.config.e2e.mts

 RUN  v4.1.5 /Users/trivikr/workspace/trivikr-test-undici-http-handler

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  14:14:44
   Duration  5.00s (transform 30ms, setup 0ms, import 208ms, tests 4.66s, environment 0ms)
```