### PR TITLE
test(e2e): run tests in default handler

### DIFF
--- a/src/request-handler.cloudwatch-logs.e2e.spec.ts
+++ b/src/request-handler.cloudwatch-logs.e2e.spec.ts
@@ -5,12 +5,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
 
-describe("UndiciHttpHandler CloudWatch Logs e2e", () => {
+describe.each([
+  { name: "default", requestHandler: undefined },
+  { name: "UndiciHttpHandler", requestHandler: new UndiciHttpHandler() },
+])("CloudWatchLogs e2e with requestHandler: $name", ({ requestHandler }) => {
   const logGroupName = `/test/undici-http-handler/${randomUUID()}`;
   const logStreamName = "test-stream";
-  const client = new CloudWatchLogs({
-    requestHandler: new UndiciHttpHandler(),
-  });
+  const client = new CloudWatchLogs({ requestHandler });
   let logGroupArn: string;
 
   beforeAll(async () => {

--- a/src/request-handler.s3.e2e.spec.ts
+++ b/src/request-handler.s3.e2e.spec.ts
@@ -5,13 +5,19 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
 
-describe("UndiciHttpHandler S3 e2e", () => {
+describe.each([
+  { name: "default", requestHandler: undefined },
+  { name: "UndiciHttpHandler", requestHandler: new UndiciHttpHandler() },
+])("S3 e2e with requestHandler: $name", ({ requestHandler }) => {
   const bucketName = `test-undici-http-handler-${randomUUID()}`;
-  const client = new S3({ requestHandler: new UndiciHttpHandler() });
+  const client = new S3({ requestHandler });
 
   beforeAll(async () => {
     await client.createBucket({ Bucket: bucketName });
-    await client.waitUntilBucketExists({ Bucket: bucketName }, { maxWaitTime: 60 });
+    await client.waitUntilBucketExists(
+      { Bucket: bucketName },
+      { maxWaitTime: 60 },
+    );
   });
 
   afterAll(async () => {
@@ -39,7 +45,7 @@ describe("UndiciHttpHandler S3 e2e", () => {
 
     // headObject should fail before put
     await expect(
-      client.headObject({ Bucket: bucketName, Key: key })
+      client.headObject({ Bucket: bucketName, Key: key }),
     ).rejects.toThrow();
 
     // Put the object
@@ -81,7 +87,7 @@ describe("UndiciHttpHandler S3 e2e", () => {
 
     // headObject should fail after delete
     await expect(
-      client.headObject({ Bucket: bucketName, Key: key })
+      client.headObject({ Bucket: bucketName, Key: key }),
     ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
This test code will move into `@aws-sdk/*` in future

Refs: https://github.com/trivikr/trivikr-test-undici-http-handler/pull/22#discussion_r3227313997

```console
$ yarn test:e2e --reporter=verbose

 RUN  v4.1.5 /Users/trivikr/workspace/trivikr-test-undici-http-handler

 ✓ src/request-handler.s3.e2e.spec.ts > S3 e2e with requestHandler: 'default' > list/head/put/get/delete 284ms
 ✓ src/request-handler.s3.e2e.spec.ts > S3 e2e with requestHandler: 'UndiciHttpHandler' > list/head/put/get/delete 456ms
 ✓ src/request-handler.cloudwatch-logs.e2e.spec.ts > CloudWatchLogs e2e with requestHandler: 'default' > startLiveTail 3331ms
 ✓ src/request-handler.cloudwatch-logs.e2e.spec.ts > CloudWatchLogs e2e with requestHandler: 'UndiciHttpHandler' > startLiveTail 3301ms

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  13:32:25
   Duration  7.65s (transform 54ms, setup 0ms, import 302ms, tests 10.53s, environment 0ms)
```