### PR TITLE
refactor: use private class fields in UndiciHttpHandler

### DIFF
--- a/.changeset/thirty-symbols-hope.md
+++ b/.changeset/thirty-symbols-hope.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": minor
+---
+
+Replace TypeScript's compile-time `private` keyword with native ECMAScript private class fields (#) for true runtime encapsulation.

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -28,32 +28,32 @@ export interface UndiciHttpHandlerOptions {
 export class UndiciHttpHandler
   implements HttpHandler<UndiciHttpHandlerOptions>
 {
-  private config: UndiciHttpHandlerOptions;
-  private externalDispatcher = false;
+  #config: UndiciHttpHandlerOptions;
+  #externalDispatcher = false;
 
   public readonly metadata = { handlerProtocol: "http/1.1" };
 
   constructor(options?: UndiciHttpHandlerOptions) {
-    this.config = { ...options };
-    if (this.config.dispatcher) {
-      this.externalDispatcher = true;
+    this.#config = { ...options };
+    if (this.#config.dispatcher) {
+      this.#externalDispatcher = true;
     }
   }
 
-  private getOrCreateDispatcher(): Dispatcher {
-    if (this.config.dispatcher) {
-      return this.config.dispatcher;
+  #getOrCreateDispatcher(): Dispatcher {
+    if (this.#config.dispatcher) {
+      return this.#config.dispatcher;
     }
 
-    this.config.dispatcher = new Agent();
+    this.#config.dispatcher = new Agent();
 
-    return this.config.dispatcher;
+    return this.#config.dispatcher;
   }
 
   public destroy(): void {
-    if (this.config.dispatcher && !this.externalDispatcher) {
-      this.config.dispatcher.destroy();
-      this.config.dispatcher = undefined;
+    if (this.#config.dispatcher && !this.#externalDispatcher) {
+      this.#config.dispatcher.destroy();
+      this.#config.dispatcher = undefined;
     }
   }
 
@@ -61,7 +61,7 @@ export class UndiciHttpHandler
     request: HttpRequest,
     { abortSignal, requestTimeout }: HttpHandlerOptions = {},
   ): Promise<{ response: HttpResponse }> {
-    const dispatcher = this.getOrCreateDispatcher();
+    const dispatcher = this.#getOrCreateDispatcher();
 
     if (abortSignal?.aborted) {
       throw Object.assign(new Error("Request aborted"), {
@@ -176,7 +176,7 @@ export class UndiciHttpHandler
     value: NonNullable<UndiciHttpHandlerOptions[K]>,
   ): void {
     if (key !== "dispatcher") {
-      (this.config as any)[key] = value;
+      (this.#config as any)[key] = value;
       return;
     }
 
@@ -188,24 +188,24 @@ export class UndiciHttpHandler
     }
 
     // No-op when the same dispatcher instance is reassigned.
-    if (value === this.config.dispatcher) {
+    if (value === this.#config.dispatcher) {
       return;
     }
 
     // Capture the previous dispatcher before assignment.
-    const previousDispatcher = this.config.dispatcher;
+    const previousDispatcher = this.#config.dispatcher;
 
     // Destroy the previous dispatcher only if it was internally created.
-    if (previousDispatcher && !this.externalDispatcher) {
+    if (previousDispatcher && !this.#externalDispatcher) {
       previousDispatcher.destroy();
     }
 
     // Assign the new value and update externalDispatcher based on it.
-    this.config.dispatcher = value as Dispatcher;
-    this.externalDispatcher = true;
+    this.#config.dispatcher = value as Dispatcher;
+    this.#externalDispatcher = true;
   }
 
   public httpHandlerConfigs(): UndiciHttpHandlerOptions {
-    return this.config ?? {};
+    return this.#config ?? {};
   }
 }

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -206,6 +206,6 @@ export class UndiciHttpHandler
   }
 
   public httpHandlerConfigs(): UndiciHttpHandlerOptions {
-    return this.#config ?? {};
+    return { ...this.#config };
   }
 }


### PR DESCRIPTION
Replace TypeScript's compile-time `private` keyword with native ECMAScript private class fields (#) for true runtime encapsulation.

Node.js 20+ and the ES2023 target support this natively without any downleveling.