### PR TITLE
feat: support bidirectional streaming by allowing HTTP/2 connections

### DIFF
--- a/.changeset/many-pugs-knock.md
+++ b/.changeset/many-pugs-knock.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": minor
+---
+
+Support bidirectional streaming by allowing HTTP/2 connections

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "undici": "^7.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1045.0",
     "@aws-sdk/client-s3": "^3.0.0",
     "@changesets/cli": "^2.31.0",

--- a/src/request-handler.bedrock-runtime.e2e.spec.ts
+++ b/src/request-handler.bedrock-runtime.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { BedrockRuntime } from "@aws-sdk/client-bedrock-runtime";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 
 import { UndiciHttpHandler } from "./undici-http-handler";
 
@@ -10,6 +10,10 @@ describe.each([
   const client = new BedrockRuntime({
     region: "us-east-1",
     requestHandler,
+  });
+
+  afterAll(() => {
+    client.destroy();
   });
 
   it("invokeModelWithBidirectionalStream", async () => {

--- a/src/request-handler.bedrock-runtime.e2e.spec.ts
+++ b/src/request-handler.bedrock-runtime.e2e.spec.ts
@@ -96,12 +96,24 @@ describe.each([
     expect(response.$metadata.httpStatusCode).toBe(200);
     expect(response.body).toBeDefined();
 
+    let receivedUsageEvent = false;
+    const receivedEventTypes: string[] = [];
+
     for await (const event of response.body!) {
       if (event?.chunk?.bytes?.byteLength) {
         const parsed = JSON.parse(new TextDecoder().decode(event.chunk.bytes));
         expect(parsed).toHaveProperty("event");
-        expect(parsed["event"]).toHaveProperty("usageEvent");
+
+        const eventType = Object.keys(parsed["event"])[0];
+        receivedEventTypes.push(eventType);
+
+        if (eventType === "usageEvent") {
+          receivedUsageEvent = true;
+        }
       }
     }
+
+    expect(receivedEventTypes.length).toBeGreaterThan(0);
+    expect(receivedUsageEvent).toBe(true);
   });
 });

--- a/src/request-handler.bedrock-runtime.e2e.spec.ts
+++ b/src/request-handler.bedrock-runtime.e2e.spec.ts
@@ -17,10 +17,10 @@ describe.each([
   });
 
   it("invokeModelWithBidirectionalStream", async () => {
-    const p = "p";
-    const s = (data: unknown) => Buffer.from(JSON.stringify(data));
+    const promptName = "p";
+    const jsonBytes = (data: unknown) => Buffer.from(JSON.stringify(data));
     const chunk = (event: unknown) => ({
-      chunk: { bytes: s({ event }) },
+      chunk: { bytes: jsonBytes({ event }) },
     });
 
     const response = await client.invokeModelWithBidirectionalStream({
@@ -30,7 +30,7 @@ describe.each([
           yield chunk({ sessionStart: {} });
           yield chunk({
             promptStart: {
-              promptName: p,
+              promptName,
               audioOutputConfiguration: {
                 mediaType: "audio/lpcm",
                 sampleRateHertz: 8000,
@@ -44,7 +44,7 @@ describe.each([
           });
           yield chunk({
             contentStart: {
-              promptName: p,
+              promptName,
               contentName: "c1",
               type: "TEXT",
               role: "SYSTEM",
@@ -53,17 +53,17 @@ describe.each([
           });
           yield chunk({
             textInput: {
-              promptName: p,
+              promptName,
               contentName: "c1",
               content: "Hi",
             },
           });
           yield chunk({
-            contentEnd: { promptName: p, contentName: "c1" },
+            contentEnd: { promptName, contentName: "c1" },
           });
           yield chunk({
             contentStart: {
-              promptName: p,
+              promptName,
               contentName: "c2",
               type: "AUDIO",
               role: "USER",
@@ -79,15 +79,15 @@ describe.each([
           });
           yield chunk({
             audioInput: {
-              promptName: p,
+              promptName,
               contentName: "c2",
               content: Buffer.from(new Uint8Array(3200)).toString("base64"),
             },
           });
           yield chunk({
-            contentEnd: { promptName: p, contentName: "c2" },
+            contentEnd: { promptName, contentName: "c2" },
           });
-          yield chunk({ promptEnd: { promptName: p } });
+          yield chunk({ promptEnd: { promptName } });
           yield chunk({ sessionEnd: {} });
         },
       },

--- a/src/request-handler.bedrock-runtime.e2e.spec.ts
+++ b/src/request-handler.bedrock-runtime.e2e.spec.ts
@@ -1,0 +1,103 @@
+import { BedrockRuntime } from "@aws-sdk/client-bedrock-runtime";
+import { describe, expect, it } from "vitest";
+
+import { UndiciHttpHandler } from "./undici-http-handler";
+
+describe.each([
+  { name: "default", requestHandler: undefined },
+  { name: "UndiciHttpHandler", requestHandler: new UndiciHttpHandler() },
+])("BedrockRuntime e2e with requestHandler: $name", ({ requestHandler }) => {
+  const client = new BedrockRuntime({
+    region: "us-east-1",
+    requestHandler,
+  });
+
+  it("invokeModelWithBidirectionalStream", async () => {
+    const p = "p";
+    const s = (data: unknown) => Buffer.from(JSON.stringify(data));
+    const chunk = (event: unknown) => ({
+      chunk: { bytes: s({ event }) },
+    });
+
+    const response = await client.invokeModelWithBidirectionalStream({
+      modelId: "amazon.nova-sonic-v1:0",
+      body: {
+        async *[Symbol.asyncIterator]() {
+          yield chunk({ sessionStart: {} });
+          yield chunk({
+            promptStart: {
+              promptName: p,
+              audioOutputConfiguration: {
+                mediaType: "audio/lpcm",
+                sampleRateHertz: 8000,
+                sampleSizeBits: 16,
+                channelCount: 1,
+                voiceId: "matthew",
+                encoding: "base64",
+                audioType: "SPEECH",
+              },
+            },
+          });
+          yield chunk({
+            contentStart: {
+              promptName: p,
+              contentName: "c1",
+              type: "TEXT",
+              role: "SYSTEM",
+              textInputConfiguration: { mediaType: "text/plain" },
+            },
+          });
+          yield chunk({
+            textInput: {
+              promptName: p,
+              contentName: "c1",
+              content: "Hi",
+            },
+          });
+          yield chunk({
+            contentEnd: { promptName: p, contentName: "c1" },
+          });
+          yield chunk({
+            contentStart: {
+              promptName: p,
+              contentName: "c2",
+              type: "AUDIO",
+              role: "USER",
+              audioInputConfiguration: {
+                mediaType: "audio/lpcm",
+                sampleRateHertz: 16000,
+                sampleSizeBits: 16,
+                channelCount: 1,
+                audioType: "SPEECH",
+                encoding: "base64",
+              },
+            },
+          });
+          yield chunk({
+            audioInput: {
+              promptName: p,
+              contentName: "c2",
+              content: Buffer.from(new Uint8Array(3200)).toString("base64"),
+            },
+          });
+          yield chunk({
+            contentEnd: { promptName: p, contentName: "c2" },
+          });
+          yield chunk({ promptEnd: { promptName: p } });
+          yield chunk({ sessionEnd: {} });
+        },
+      },
+    });
+
+    expect(response.$metadata.httpStatusCode).toBe(200);
+    expect(response.body).toBeDefined();
+
+    for await (const event of response.body!) {
+      if (event?.chunk?.bytes?.byteLength) {
+        const parsed = JSON.parse(new TextDecoder().decode(event.chunk.bytes));
+        expect(parsed).toHaveProperty("event");
+        expect(parsed["event"]).toHaveProperty("usageEvent");
+      }
+    }
+  });
+});

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -111,12 +111,10 @@ describe("UndiciHttpHandler", () => {
   describe("constructor and create", () => {
     it("creates a new instance with no options", () => {
       handler = new UndiciHttpHandler();
-      expect(handler.metadata).toEqual({ handlerProtocol: "http/1.1" });
     });
 
     it("creates a new instance with options", () => {
       handler = new UndiciHttpHandler({ logger: createMockLogger() });
-      expect(handler.metadata).toEqual({ handlerProtocol: "http/1.1" });
     });
   });
 

--- a/src/undici-http-handler.spec.ts
+++ b/src/undici-http-handler.spec.ts
@@ -108,16 +108,6 @@ describe("UndiciHttpHandler", () => {
     handler?.destroy();
   });
 
-  describe("constructor and create", () => {
-    it("creates a new instance with no options", () => {
-      handler = new UndiciHttpHandler();
-    });
-
-    it("creates a new instance with options", () => {
-      handler = new UndiciHttpHandler({ logger: createMockLogger() });
-    });
-  });
-
   describe("handle", () => {
     it("makes a basic GET request", async () => {
       handler = new UndiciHttpHandler();

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -45,7 +45,7 @@ export class UndiciHttpHandler
       return this.#config.dispatcher;
     }
 
-    this.#config.dispatcher = new Agent();
+    this.#config.dispatcher = new Agent({ allowH2: true });
 
     return this.#config.dispatcher;
   }

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -31,8 +31,6 @@ export class UndiciHttpHandler
   #config: UndiciHttpHandlerOptions;
   #externalDispatcher = false;
 
-  public readonly metadata = { handlerProtocol: "http/1.1" };
-
   constructor(options?: UndiciHttpHandlerOptions) {
     this.#config = { ...options };
     if (this.#config.dispatcher) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,6 +87,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-bedrock-runtime@npm:^3.1045.0":
+  version: 3.1045.0
+  resolution: "@aws-sdk/client-bedrock-runtime@npm:3.1045.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": "npm:5.2.0"
+    "@aws-crypto/sha256-js": "npm:5.2.0"
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.39"
+    "@aws-sdk/eventstream-handler-node": "npm:^3.972.14"
+    "@aws-sdk/middleware-eventstream": "npm:^3.972.10"
+    "@aws-sdk/middleware-host-header": "npm:^3.972.10"
+    "@aws-sdk/middleware-logger": "npm:^3.972.10"
+    "@aws-sdk/middleware-recursion-detection": "npm:^3.972.11"
+    "@aws-sdk/middleware-user-agent": "npm:^3.972.38"
+    "@aws-sdk/middleware-websocket": "npm:^3.972.16"
+    "@aws-sdk/region-config-resolver": "npm:^3.972.13"
+    "@aws-sdk/token-providers": "npm:3.1045.0"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-endpoints": "npm:^3.996.8"
+    "@aws-sdk/util-user-agent-browser": "npm:^3.972.10"
+    "@aws-sdk/util-user-agent-node": "npm:^3.973.24"
+    "@smithy/config-resolver": "npm:^4.4.17"
+    "@smithy/core": "npm:^3.23.17"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
+    "@smithy/eventstream-serde-config-resolver": "npm:^4.3.14"
+    "@smithy/eventstream-serde-node": "npm:^4.2.14"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/hash-node": "npm:^4.2.14"
+    "@smithy/invalid-dependency": "npm:^4.2.14"
+    "@smithy/middleware-content-length": "npm:^4.2.14"
+    "@smithy/middleware-endpoint": "npm:^4.4.32"
+    "@smithy/middleware-retry": "npm:^4.5.7"
+    "@smithy/middleware-serde": "npm:^4.2.20"
+    "@smithy/middleware-stack": "npm:^4.2.14"
+    "@smithy/node-config-provider": "npm:^4.3.14"
+    "@smithy/node-http-handler": "npm:^4.6.1"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/smithy-client": "npm:^4.12.13"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/url-parser": "npm:^4.2.14"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-body-length-browser": "npm:^4.2.2"
+    "@smithy/util-body-length-node": "npm:^4.2.3"
+    "@smithy/util-defaults-mode-browser": "npm:^4.3.49"
+    "@smithy/util-defaults-mode-node": "npm:^4.2.54"
+    "@smithy/util-endpoints": "npm:^3.4.2"
+    "@smithy/util-middleware": "npm:^4.2.14"
+    "@smithy/util-retry": "npm:^4.3.6"
+    "@smithy/util-stream": "npm:^4.5.25"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c6b0407a33d582606d6aa3b1f4ad77dc284e6a2231955dea8912085757ea557e110d315c963c7a633febce0d2cd2dd1195adcdbc99f9ecdf24cd80c06d2c0cd4
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-cloudwatch-logs@npm:^3.1045.0":
   version: 3.1045.0
   resolution: "@aws-sdk/client-cloudwatch-logs@npm:3.1045.0"
@@ -366,6 +421,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/eventstream-handler-node@npm:^3.972.14":
+  version: 3.972.14
+  resolution: "@aws-sdk/eventstream-handler-node@npm:3.972.14"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/eventstream-codec": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9e91aeddfbc23d41b8628c8ed93582857941c3caabe94aeccc28bfe0156270d392c90d214ed24bf8367d16266b274b4cd01a96069ed0d6ab64adfd7b369ab0b3
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-bucket-endpoint@npm:^3.972.10":
   version: 3.972.10
   resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.972.10"
@@ -378,6 +445,18 @@ __metadata:
     "@smithy/util-config-provider": "npm:^4.2.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/5529288142e0ebfbd985a257dbbb0f3510981a6ef56ce449465458ca12f7bcbbb9bfba9e1788c925329443604d4a438275f30254ef1d47e7931da798fb6e6765
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-eventstream@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/middleware-eventstream@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/425a0cf0d1c3c079f63fb4a2017350867e4f62082bf261375387a64f1b41d3bf2392a7b38590306ebf440c211083e83c6089c5dfb624b81c41bea9a8a7f98dd4
   languageName: node
   linkType: hard
 
@@ -511,6 +590,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/middleware-websocket@npm:^3.972.16":
+  version: 3.972.16
+  resolution: "@aws-sdk/middleware-websocket@npm:3.972.16"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@aws-sdk/util-format-url": "npm:^3.972.10"
+    "@smithy/eventstream-codec": "npm:^4.2.14"
+    "@smithy/eventstream-serde-browser": "npm:^4.2.14"
+    "@smithy/fetch-http-handler": "npm:^5.3.17"
+    "@smithy/protocol-http": "npm:^5.3.14"
+    "@smithy/signature-v4": "npm:^5.3.14"
+    "@smithy/types": "npm:^4.14.1"
+    "@smithy/util-base64": "npm:^4.3.2"
+    "@smithy/util-hex-encoding": "npm:^4.2.2"
+    "@smithy/util-utf8": "npm:^4.2.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/2eb40a402be07af99a5b11e63d1ef408c8d0e90fd6692665cb3e8f5d827841f1dedf7c84a5b233b76141dcd9c0d8210194286779808a639149eff6cadf2ba458
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/nested-clients@npm:^3.997.6":
   version: 3.997.6
   resolution: "@aws-sdk/nested-clients@npm:3.997.6"
@@ -600,6 +699,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/token-providers@npm:3.1045.0":
+  version: 3.1045.0
+  resolution: "@aws-sdk/token-providers@npm:3.1045.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.8"
+    "@aws-sdk/nested-clients": "npm:^3.997.6"
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/property-provider": "npm:^4.2.14"
+    "@smithy/shared-ini-file-loader": "npm:^4.4.9"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ec5e9ab6398e6b779bb71ac1034becaf09efba3b415cb2bf35b878ec656ba2cbdf7b4413f5316bf19399f193e5cd8a6756d57e7a35c311f4479ede995c30c517
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/types@npm:^3.222.0, @aws-sdk/types@npm:^3.973.8":
   version: 3.973.8
   resolution: "@aws-sdk/types@npm:3.973.8"
@@ -629,6 +743,18 @@ __metadata:
     "@smithy/util-endpoints": "npm:^3.4.2"
     tslib: "npm:^2.6.2"
   checksum: 10c0/66f17e85357ab8e265ab7d1c9a69a064ad3bea99420c786be9ef1f92bc71dca22d328bbceeaf6c64b4a3c37161b78318a3e4a424bf247dcb211d7ae29344db2f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-format-url@npm:^3.972.10":
+  version: 3.972.10
+  resolution: "@aws-sdk/util-format-url@npm:3.972.10"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.8"
+    "@smithy/querystring-builder": "npm:^4.2.14"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d97445228f8ae9f8b7b53659e57d68c28f406d025d2902c6d1ba9bbb386d990011951d77f5a3d82360dc7bc5fd39a12c5e8bc27975ede72e586466597857cd19
   languageName: node
   linkType: hard
 
@@ -1206,6 +1332,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/core@npm:^3.24.1":
+  version: 3.24.1
+  resolution: "@smithy/core@npm:3.24.1"
+  dependencies:
+    "@aws-crypto/crc32": "npm:5.2.0"
+    "@smithy/types": "npm:^4.14.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b5fee2698758bf6824063d9bc51ade93057231eee6caa45fe6a54e6acd793fadb69c07cd7676459555e9a0d9e288fbd5f29163bb4ca8b861a344a840b750dc6a
+  languageName: node
+  linkType: hard
+
 "@smithy/credential-provider-imds@npm:^4.2.14":
   version: 4.3.0
   resolution: "@smithy/credential-provider-imds@npm:4.3.0"
@@ -1214,6 +1351,16 @@ __metadata:
     "@smithy/types": "npm:^4.14.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/b3bc4c5f3123dee1043fe3ff22c1c24d8e00cad66f41739a6ab8489d1571167444bd0d4568c3b10ad624adb35c73f39a6fa1cfaf6d830aa3b0dbb4f8c654253c
+  languageName: node
+  linkType: hard
+
+"@smithy/eventstream-codec@npm:^4.2.14":
+  version: 4.3.1
+  resolution: "@smithy/eventstream-codec@npm:4.3.1"
+  dependencies:
+    "@smithy/core": "npm:^3.24.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/71c0e194988897c82eba750d7c09d4196907b815a73c6d092f9edc1238e439489899b593a1b3b6e9ed8a2fe83beef770712eeb15f0e7615a3ae9ca048da27f46
   languageName: node
   linkType: hard
 
@@ -1561,6 +1708,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@smithy/util-hex-encoding@npm:^4.2.2":
+  version: 4.3.1
+  resolution: "@smithy/util-hex-encoding@npm:4.3.1"
+  dependencies:
+    "@smithy/core": "npm:^3.24.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e4ec532008cd132e65cb0084dc8966fa8288efe2f20417e235593ba53f0f06e2cd51b4eb530e995060760242b82f62aadadb53f9deb07def50ee52c772efd468
+  languageName: node
+  linkType: hard
+
 "@smithy/util-middleware@npm:^4.2.14":
   version: 4.3.0
   resolution: "@smithy/util-middleware@npm:4.3.0"
@@ -1641,6 +1798,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trivikr-test/undici-http-handler@workspace:."
   dependencies:
+    "@aws-sdk/client-bedrock-runtime": "npm:^3.1045.0"
     "@aws-sdk/client-cloudwatch-logs": "npm:^3.1045.0"
     "@aws-sdk/client-s3": "npm:^3.0.0"
     "@changesets/cli": "npm:^2.31.0"


### PR DESCRIPTION
Sets `allowH2: true` on the undici Agent to enable HTTP/2, which is required for bidirectional streaming operations.
Adds BedrockRuntime e2e test to verify the behavior.

Fixes: https://github.com/trivikr/trivikr-test-undici-http-handler/issues/31

---

All e2e tests are successful

```console
$ yarn test:e2e

 RUN  v4.1.5 /Users/trivikr/workspace/trivikr-test-undici-http-handler

 Test Files  3 passed (3)
      Tests  12 passed (12)
   Start at  12:51:49
   Duration  8.06s (transform 147ms, setup 0ms, import 963ms, tests 14.47s, environment 0ms)
```