### PR TITLE
docs: deprecate in favor of @smithy/undici-http-handler

### DIFF
--- a/.changeset/some-taxes-ring.md
+++ b/.changeset/some-taxes-ring.md
@@ -2,4 +2,4 @@
 "@trivikr-test/undici-http-handler": minor
 ---
 
-Deprecated in favor of @smithy/undici-http-handler
+Deprecated in favor of `@smithy/undici-http-handler`.

--- a/.changeset/some-taxes-ring.md
+++ b/.changeset/some-taxes-ring.md
@@ -1,0 +1,5 @@
+---
+"@trivikr-test/undici-http-handler": minor
+---
+
+Deprecated in favor of @smithy/undici-http-handler

--- a/README.md
+++ b/README.md
@@ -1,63 +1,12 @@
 # @trivikr-test/undici-http-handler
 
-Smithy-compatible HTTP handler backed by Node.js undici.
+> **⚠️ Deprecated:** This package has moved to [`@smithy/undici-http-handler`][].
+>
+> Please migrate to the new package by replacing the import.
+>
+> ```diff
+> - import { UndiciHttpHandler } from "@trivikr-test/undici-http-handler";
+> + import { UndiciHttpHandler } from "@smithy/undici-http-handler";
+> ```
 
-## Usage
-
-Use `UndiciHttpHandler` as a Smithy-compatible request handler for generated
-clients. It uses undici for HTTP transport, and accepts optional undici
-`Dispatcher` to set up transport details.
-
-### Basic example
-
-```js
-import { S3 } from "@aws-sdk/client-s3";
-import { UndiciHttpHandler } from "@trivikr-test/undici-http-handler";
-
-const client = new S3({
-  requestHandler: new UndiciHttpHandler(),
-});
-
-client.listBuckets().then(console.log);
-```
-
-### Configuring undici Dispatcher
-
-Pass an undici `Dispatcher` to configure transport behavior such as connection
-pooling and timeouts.
-
-```js
-import { S3 } from "@aws-sdk/client-s3";
-import { UndiciHttpHandler } from "@trivikr-test/undici-http-handler";
-import { Agent } from "undici";
-
-const dispatcher = new Agent({
-  connections: 50,
-  headersTimeout: 3000,
-  bodyTimeout: 3000,
-  connect: {
-    timeout: 3000,
-  },
-});
-
-const client = new S3({
-  requestHandler: new UndiciHttpHandler({ dispatcher }),
-});
-
-client.listBuckets().then(console.log);
-```
-
-## Benchmarks
-
-Our benchmarks spin up a local HTTP server and runs two scenarios:
-
-- **10 sequential GETs** – measures per-request latency when requests are issued
-  one after another.
-- **50 concurrent GETs** – measures throughput under parallel load using
-  `Promise.all`.
-
-The results show UndiciHttpHandler spends **15%-25%** less time as compared to
-NodeHttpHandler from `@smithy/node-http-handler`.
-
-We recommend running benchmarks for your own use case on your own setup, as
-results will vary depending on workload, network conditions, and environment.
+[`@smithy/undici-http-handler`]: https://www.npmjs.com/package/@smithy/undici-http-handler


### PR DESCRIPTION
Deprecation in favor of [@smithy/undici-http-handler](https://www.npmjs.com/package/@smithy/undici-http-handler)