### PR TITLE
chore: deprecate in types and at runtime

### DIFF
--- a/.changeset/some-taxes-ring.md
+++ b/.changeset/some-taxes-ring.md
@@ -2,4 +2,4 @@
 "@trivikr-test/undici-http-handler": minor
 ---
 
-Deprecated in favor of `@smithy/undici-http-handler`.
+Deprecated in favor of `@smithy/undici-http-handler`. The `UndiciHttpHandler` class and `UndiciHttpHandlerOptions` interface are marked with `@deprecated` JSDoc tags, and a Node.js `DeprecationWarning` is emitted the first time `UndiciHttpHandler` is instantiated.

--- a/src/undici-http-handler.ts
+++ b/src/undici-http-handler.ts
@@ -6,8 +6,12 @@ import { buildQueryString } from "@smithy/querystring-builder";
 import type { HttpHandlerOptions, Logger } from "@smithy/types";
 import { Agent, Dispatcher } from "undici";
 
+let deprecationWarningEmitted = false;
+
 /**
  * Options for the UndiciHttpHandler.
+ *
+ * @deprecated Use `UndiciHttpHandlerOptions` from `@smithy/undici-http-handler` instead.
  */
 export interface UndiciHttpHandlerOptions {
   /**
@@ -24,6 +28,8 @@ export interface UndiciHttpHandlerOptions {
 /**
  * An HTTP handler that uses undici instead of Node.js native http/https modules.
  * Smithy-compatible request handler backed by undici.
+ *
+ * @deprecated Use `UndiciHttpHandler` from `@smithy/undici-http-handler` instead.
  */
 export class UndiciHttpHandler
   implements HttpHandler<UndiciHttpHandlerOptions>
@@ -32,6 +38,16 @@ export class UndiciHttpHandler
   #externalDispatcher = false;
 
   constructor(options?: UndiciHttpHandlerOptions) {
+    if (!deprecationWarningEmitted) {
+      deprecationWarningEmitted = true;
+      process.emitWarning(
+        "The package '@trivikr-test/undici-http-handler' is deprecated. " +
+          "Please migrate to '@smithy/undici-http-handler'.",
+        "DeprecationWarning",
+        "DEP_TRIVIKR_TEST_UNDICI_HTTP_HANDLER",
+      );
+    }
+
     this.#config = { ...options };
     if (this.#config.dispatcher) {
       this.#externalDispatcher = true;


### PR DESCRIPTION
The types/runtime deprecation of https://github.com/trivikr/trivikr-test-undici-http-handler/pull/34